### PR TITLE
feat: implement Google OAuth2 login

### DIFF
--- a/src/main/java/com/kt/mindLog/controller/auth/AuthController.java
+++ b/src/main/java/com/kt/mindLog/controller/auth/AuthController.java
@@ -22,11 +22,20 @@ public class AuthController {
 
 	// KAKAO
 	@GetMapping("/kakao/callback")
-	public LoginResponse callback(@RequestParam("code") String code) {
+	public LoginResponse kakaoLogin(@RequestParam("code") String code) {
 
 		String accessToken = AuthService.getAccessTokenFromKakao(code);
-		String email = AuthService.getUserInfo(accessToken);
+		String email = AuthService.getKakaoUserInfo(accessToken);
 
 		return userService.login(email, LoginType.KAKAO);
+	}
+
+	// GOOGLE
+	@GetMapping("/google/callback")
+	public LoginResponse googleLogin(@RequestParam("code") String code) {
+		String accessToken = AuthService.getAccessTokenFromGoogle(code);
+		String email = AuthService.getGoogleUserInfo(accessToken);
+
+		return userService.login(email, LoginType.GOOGLE);
 	}
 }

--- a/src/main/java/com/kt/mindLog/dto/oauth/response/GoogleTokenResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/oauth/response/GoogleTokenResponse.java
@@ -1,0 +1,4 @@
+package com.kt.mindLog.dto.oauth.response;
+
+public record GoogleTokenResponse() {
+}

--- a/src/main/java/com/kt/mindLog/dto/oauth/response/GoogleTokenResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/oauth/response/GoogleTokenResponse.java
@@ -1,4 +1,26 @@
 package com.kt.mindLog.dto.oauth.response;
 
-public record GoogleTokenResponse() {
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleTokenResponse(
+	@JsonProperty("token_type")
+	String tokenType,
+
+	@JsonProperty("access_token")
+	String accessToken,
+
+	@JsonProperty("id_token")
+	String idToken,
+
+	@JsonProperty("expires_in")
+	Integer expiresIn,
+
+	@JsonProperty("refresh_token")
+	String refreshToken,
+
+	@JsonProperty("scope")
+	String scope
+) {
 }

--- a/src/main/java/com/kt/mindLog/dto/oauth/response/GoogleUserInfoResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/oauth/response/GoogleUserInfoResponse.java
@@ -1,0 +1,4 @@
+package com.kt.mindLog.dto.oauth.response;
+
+public record GoogleUserInfoResponse() {
+}

--- a/src/main/java/com/kt/mindLog/dto/oauth/response/GoogleUserInfoResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/oauth/response/GoogleUserInfoResponse.java
@@ -1,4 +1,14 @@
 package com.kt.mindLog.dto.oauth.response;
 
-public record GoogleUserInfoResponse() {
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleUserInfoResponse(
+	@JsonProperty("email")
+	String email,
+
+	@JsonProperty("email_verified")
+	Boolean emailVerified
+) {
 }

--- a/src/main/java/com/kt/mindLog/dto/oauth/response/KakaoTokenResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/oauth/response/KakaoTokenResponse.java
@@ -3,31 +3,27 @@ package com.kt.mindLog.dto.oauth.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class KakaoTokenResponse {
+public record KakaoTokenResponse(
 	@JsonProperty("token_type")
-	public String tokenType;
+	String tokenType,
 
 	@JsonProperty("access_token")
-	public String accessToken;
+    String accessToken,
 
-	@JsonProperty("id_token")
-	public String idToken;
+    @JsonProperty("id_token")
+	String idToken,
 
-	@JsonProperty("expires_in")
-	public Integer expiresIn;
+    @JsonProperty("expires_in")
+    Integer expiresIn,
 
-	@JsonProperty("refresh_token")
-	public String refreshToken;
+   @JsonProperty("refresh_token")
+   String refreshToken,
 
-	@JsonProperty("refresh_token_expires_in")
-	public Integer refreshTokenExpiresIn;
+   @JsonProperty("refresh_token_expires_in")
+   Integer refreshTokenExpiresIn,
 
-	@JsonProperty("scope")
-	public String scope;
+   @JsonProperty("scope")
+   String scope
+) {
 }

--- a/src/main/java/com/kt/mindLog/dto/oauth/response/KakaoUserInfoResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/oauth/response/KakaoUserInfoResponse.java
@@ -3,30 +3,20 @@ package com.kt.mindLog.dto.oauth.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class KakaoUserInfoResponse {
-	@JsonProperty("id")
-	private Long id;
-
+public record KakaoUserInfoResponse(
 	@JsonProperty("kakao_account")
-	private KakaoAccount kakaoAccount;
-
-	@Getter
-	@NoArgsConstructor
+	KakaoAccount kakaoAccount
+) {
 	@JsonIgnoreProperties(ignoreUnknown = true)
-	public static class KakaoAccount {
+	public record KakaoAccount(
 		@JsonProperty("email")
-		private String email;
+		String email,
 
 		@JsonProperty("is_email_valid")
-		private Boolean isEmailValid;
+		Boolean isEmailValid,
 
 		@JsonProperty("is_email_verified")
-		private Boolean isEmailVerified;
-	}
+		Boolean isEmailVerified
+	) {}
 }

--- a/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
@@ -9,9 +9,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-	// Kakao OAuth
+	// KAKAO OAuth
 	KAKAO_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "카카오 액세스 토큰 발급에 실패했습니다."),
 	KAKAO_USER_INFO_ERROR(HttpStatus.BAD_REQUEST, "카카오 유저 정보를 정상적으로 가져오지 못했습니다."),
+
+	// GOOGLE OAuth
+	GOOGLE_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "구글 액세스 토큰 발급에 실패했습니다."),
+	GOOGLE_USER_INFO_ERROR(HttpStatus.BAD_REQUEST, "구글 유저 정보를 정상적으로 가져오지 못했습니다."),
+
+	// NAVER OAuth
+	NAVER_TOKEN_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "네이버 액세스 토큰 발급에 실패했습니다."),
+	NAVER_USER_INFO_ERROR(HttpStatus.BAD_REQUEST, "네이버 유저 정보를 정상적으로 가져오지 못했습니다."),
 
 	//auth
 	INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 접근입니다. 다시 로그인을 시도해주시기 바랍니다."),

--- a/src/main/java/com/kt/mindLog/global/property/GoogleProperties.java
+++ b/src/main/java/com/kt/mindLog/global/property/GoogleProperties.java
@@ -1,0 +1,4 @@
+package com.kt.mindLog.global.property;
+
+public class GoogleProperties {
+}

--- a/src/main/java/com/kt/mindLog/global/property/GoogleProperties.java
+++ b/src/main/java/com/kt/mindLog/global/property/GoogleProperties.java
@@ -1,4 +1,15 @@
 package com.kt.mindLog.global.property;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@ConfigurationProperties(prefix = "google")
+@AllArgsConstructor
+@Getter
 public class GoogleProperties {
+	private final String clientId;
+	private final String clientSecret;
+	private final String redirectUri;
 }

--- a/src/main/java/com/kt/mindLog/service/auth/AuthService.java
+++ b/src/main/java/com/kt/mindLog/service/auth/AuthService.java
@@ -6,11 +6,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.kt.mindLog.dto.oauth.response.GoogleTokenResponse;
+import com.kt.mindLog.dto.oauth.response.GoogleUserInfoResponse;
 import com.kt.mindLog.dto.oauth.response.KakaoTokenResponse;
 import com.kt.mindLog.dto.oauth.response.KakaoUserInfoResponse;
 import com.kt.mindLog.global.common.exception.CustomException;
 import com.kt.mindLog.global.common.exception.ErrorCode;
 import com.kt.mindLog.global.common.support.Preconditions;
+import com.kt.mindLog.global.property.GoogleProperties;
 import com.kt.mindLog.global.property.KakaoProperties;
 
 import lombok.RequiredArgsConstructor;
@@ -20,14 +23,36 @@ import reactor.core.publisher.Mono;
 @Service
 public class AuthService {
 	private final KakaoProperties kakaoProperties;
-	private final String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com";
-	private final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+	private final GoogleProperties googleProperties;
+
+	private static final String AUTHORIZATION = "Authorization";
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	// OAuth hosts
+	private static final String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com";
+	private static final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com";
+
+	private static final String GOOGLE_TOKEN_URL_HOST = "https://oauth2.googleapis.com";
+	private static final String GOOGLE_USER_URL_HOST = "https://www.googleapis.com";
+
+	// OAuth endpoints
+	private static final String KAKAO_TOKEN_URI = "/oauth/token";
+	private static final String KAKAO_USER_URI = "/v2/user/me";
+
+	private static final String GOOGLE_TOKEN_URI = "/token";
+	private static final String GOOGLE_USER_URI = "/oauth2/v3/userinfo";
+
+	// OAuth WebClients
+	private final WebClient kakaoAuthClient = WebClient.create(KAUTH_TOKEN_URL_HOST);
+	private final WebClient kakaoApiClient = WebClient.create(KAUTH_USER_URL_HOST);
+	private final WebClient googleAuthClient = WebClient.create(GOOGLE_TOKEN_URL_HOST);
+	private final WebClient googleApiClient = WebClient.create(GOOGLE_USER_URL_HOST);
 
 	// KAKAO
 	public String getAccessTokenFromKakao(String code) {
-		KakaoTokenResponse response = WebClient.create(KAUTH_TOKEN_URL_HOST)
+		KakaoTokenResponse response = kakaoAuthClient
 			.post()
-			.uri("/oauth/token")
+			.uri(KAKAO_TOKEN_URI)
 			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
 			.body(BodyInserters.fromFormData("grant_type", "authorization_code")
 				.with("client_id", kakaoProperties.getClientId())
@@ -36,33 +61,69 @@ public class AuthService {
 				.with("code", code))
 			.retrieve()
 			.onStatus(HttpStatusCode::isError,
-				ClientResponse -> Mono.error(new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED)))
+				clientResponse -> Mono.error(new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED)))
 			.bodyToMono(KakaoTokenResponse.class)
 			.block();
 
-		return response.getAccessToken();
+		return response.accessToken();
 	}
 
-	public String getUserInfo(String accessToken) {
-		KakaoUserInfoResponse userInfo = WebClient.create(KAUTH_USER_URL_HOST)
+	public String getKakaoUserInfo(String accessToken) {
+		KakaoUserInfoResponse userInfo = kakaoApiClient
 			.get()
-			.uri("/v2/user/me")
-			.header("Authorization", "Bearer " + accessToken)
+			.uri(KAKAO_USER_URI)
+			.header(AUTHORIZATION, BEARER_PREFIX + accessToken)
 			.retrieve()
 			.bodyToMono(KakaoUserInfoResponse.class)
 			.block();
 
 		Preconditions.validate(userInfo != null, ErrorCode.KAKAO_USER_INFO_ERROR);
-		Preconditions.validate(userInfo.getKakaoAccount() != null, ErrorCode.KAKAO_USER_INFO_ERROR);
+		Preconditions.validate(userInfo.kakaoAccount() != null, ErrorCode.KAKAO_USER_INFO_ERROR);
 
-		String email = userInfo.getKakaoAccount().getEmail();
+		String email = userInfo.kakaoAccount().email();
 
 		Preconditions.validate(email != null, ErrorCode.KAKAO_USER_INFO_ERROR);
 
 		return email;
 	}
 
+	// GOOGLE
+	public String getAccessTokenFromGoogle(String code) {
+		GoogleTokenResponse response = googleAuthClient
+			.post()
+			.uri(GOOGLE_TOKEN_URI)
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.body(BodyInserters.fromFormData("grant_type", "authorization_code")
+				.with("client_id", googleProperties.getClientId())
+				.with("client_secret", googleProperties.getClientSecret())
+				.with("redirect_uri", googleProperties.getRedirectUri())
+				.with("code", code))
+			.retrieve()
+			.onStatus(HttpStatusCode::isError,
+				clientResponse -> Mono.error(new CustomException(ErrorCode.GOOGLE_TOKEN_REQUEST_FAILED)))
+			.bodyToMono(GoogleTokenResponse.class)
+			.block();
 
+		return response.accessToken();
+	}
 
+	public String getGoogleUserInfo(String accessToken) {
+		GoogleUserInfoResponse userInfo = googleApiClient
+			.get()
+			.uri(GOOGLE_USER_URI)
+			.header(AUTHORIZATION, BEARER_PREFIX + accessToken)
+			.retrieve()
+			.onStatus(HttpStatusCode::isError,
+				clientResponse -> Mono.error(new CustomException(ErrorCode.GOOGLE_USER_INFO_ERROR)))
+			.bodyToMono(GoogleUserInfoResponse.class)
+			.block();
 
+		Preconditions.validate(userInfo != null, ErrorCode.GOOGLE_USER_INFO_ERROR);
+
+		String email = userInfo.email();
+
+		Preconditions.validate(email != null, ErrorCode.GOOGLE_USER_INFO_ERROR);
+
+		return email;
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,8 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
   redirect-uri: ${KAKAO_REDIRECT_URI}
+
+google:
+  client-id: ${GOOGLE_CLIENT_ID}
+  client-secret: ${GOOGLE_CLIENT_SECRET}
+  redirect-uri: ${GOOGLE_REDIRECT_URI}


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #9 


## 🔨변경 사항(Changes)
-구글 인가 코드 기반 토큰 발급 및 유저 이메일 요청 로직 구현
-AuthService > host, endpoint, authorization header 상수화 및 WebClient 중복 처리
-구글, 네이버 관련 에러코드 추가
-카카오 관련 DTO > class 에서 record 로 변경 및 email 만 받아오도록 수정 (provider Id 삭제)
-application.yml / GoogleProperties > Google 관련 환경변수 추가 (clientId, clientSecret, redirectUri)


## 😉리뷰 요구사항
나중에 시간 가능하실 때 구글 로그인 테스트 해주시면 감사하겠습니다!



<br/>
