### PR TITLE
refactor: generalize S3 upload to handle profile and persona image

### DIFF
--- a/src/main/java/com/kt/mindLog/service/s3/S3Path.java
+++ b/src/main/java/com/kt/mindLog/service/s3/S3Path.java
@@ -1,0 +1,6 @@
+package com.kt.mindLog.service.s3;
+
+public enum S3Path {
+	PERSONA,
+	PROFILE
+}

--- a/src/main/java/com/kt/mindLog/service/s3/S3Service.java
+++ b/src/main/java/com/kt/mindLog/service/s3/S3Service.java
@@ -33,19 +33,19 @@ public class S3Service {
 
 	private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "webp");
 
-	public String uploadProfileImage(MultipartFile profile) {
+	public String uploadImage(MultipartFile file, S3Path path) {
 
-		validateFile(profile);
+		validateFile(file);
 
-		String fileName = "profile/" + UUID.randomUUID() + "_" + profile.getOriginalFilename();
+		String fileName = path.name().toLowerCase() + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
 
 		try {
 			ObjectMetadata metadata = new ObjectMetadata();
-			metadata.setContentLength(profile.getSize());
-			metadata.setContentType(profile.getContentType());
+			metadata.setContentLength(file.getSize());
+			metadata.setContentType(file.getContentType());
 
 			amazonS3.putObject(
-				new PutObjectRequest(bucket, fileName, profile.getInputStream(), metadata)
+				new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata)
 			);
 		} catch (AmazonS3Exception e) {
 			log.error("S3 upload failed. Status Code: {}, Error Message: {}", e.getStatusCode(), e.getMessage());
@@ -59,21 +59,21 @@ public class S3Service {
 		return amazonS3.getUrl(bucket, fileName).toString();
 	}
 
-	private void validateFile(MultipartFile profile) {
+	private void validateFile(MultipartFile file) {
 		// 빈 파일 여부 검증
-		Preconditions.validate(!profile.isEmpty(), ErrorCode.EMPTY_FILE);
+		Preconditions.validate(!file.isEmpty(), ErrorCode.EMPTY_FILE);
 
 		// 이미지 파일 타입 검증
 		Preconditions.validate(
-			profile.getContentType() != null && profile.getContentType().startsWith("image"),
+			file.getContentType() != null && file.getContentType().startsWith("image"),
 			ErrorCode.INVALID_FILE_TYPE
 		);
 
 		// 파일 크기 검증
-		Preconditions.validate(profile.getSize() <= maxFileSize, ErrorCode.FILE_SIZE_EXCEEDED);
+		Preconditions.validate(file.getSize() <= maxFileSize, ErrorCode.FILE_SIZE_EXCEEDED);
 
 		// 확장자 검증
-		String extension = extractExtenstion(profile.getOriginalFilename());
+		String extension = extractExtenstion(file.getOriginalFilename());
 		Preconditions.validate(
 			ALLOWED_EXTENSIONS.contains(extension.toLowerCase()),
 			ErrorCode.INVALID_FILE_EXTENSION

--- a/src/main/java/com/kt/mindLog/service/user/UserService.java
+++ b/src/main/java/com/kt/mindLog/service/user/UserService.java
@@ -13,6 +13,7 @@ import com.kt.mindLog.dto.user.request.UserCreateRequest;
 import com.kt.mindLog.dto.user.response.LoginResponse;
 import com.kt.mindLog.global.common.exception.ErrorCode;
 import com.kt.mindLog.repository.UserRepository;
+import com.kt.mindLog.service.s3.S3Path;
 import com.kt.mindLog.service.s3.S3Service;
 
 import lombok.RequiredArgsConstructor;
@@ -54,7 +55,7 @@ public class UserService {
 
 		User user = userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
 
-		String profileImageUrl = s3Service.uploadProfileImage(profile);
+		String profileImageUrl = s3Service.uploadImage(profile, S3Path.PROFILE);
 
 		user.updateUserInfo(
 			request.nickname(),


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #번호


## 🔨변경 사항(Changes)
-페르소나와 프로필 이미지 저장을 위한 S3 이미지 업로드 로직 공통화
-ENUM 으로 PERSONA, PROFILE 을 관리하면서 파라미터로 받는 형식으로 리팩토링

## 😉리뷰 요구사항
피드백이 잘 반영되었는지 검토 부탁드립니다


<br/>
