### PR TITLE
feat: session APIs (inactive, finalize)

### DIFF
--- a/src/main/java/com/kt/mindLog/controller/session/SessionController.java
+++ b/src/main/java/com/kt/mindLog/controller/session/SessionController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.mindLog.dto.session.request.SessionCreateRequest;
 import com.kt.mindLog.dto.session.request.SessionReceiveRequest;
+import com.kt.mindLog.dto.session.response.ActiveSessionResponse;
 import com.kt.mindLog.dto.session.response.SessionDetailResponse;
 import com.kt.mindLog.dto.session.response.SessionListResponses;
 import com.kt.mindLog.dto.session.response.SessionResponse;
@@ -59,5 +60,10 @@ public class SessionController {
 	@GetMapping("/{sessionId}")
 	public SessionDetailResponse getSessionDetail(@Login CustomUser user, @PathVariable UUID sessionId) {
 		return sessionService.getSessionDetail(user.getId(), sessionId);
+	}
+
+	@GetMapping("/active")
+	public ActiveSessionResponse getActiveSession(@Login CustomUser user) {
+		return sessionService.getActiveSession(user.getId());
 	}
 }

--- a/src/main/java/com/kt/mindLog/controller/session/SessionController.java
+++ b/src/main/java/com/kt/mindLog/controller/session/SessionController.java
@@ -66,4 +66,9 @@ public class SessionController {
 	public ActiveSessionResponse getActiveSession(@Login CustomUser user) {
 		return sessionService.getActiveSession(user.getId());
 	}
+
+	@PostMapping(value = "/{sessionId}/finalize", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public Flux<Object> finalizeSession(@Login CustomUser user, @PathVariable UUID sessionId) {
+		return sessionMessageService.finalizeSession(sessionId, user.getId());
+	}
 }

--- a/src/main/java/com/kt/mindLog/domain/session/CrisisLogs.java
+++ b/src/main/java/com/kt/mindLog/domain/session/CrisisLogs.java
@@ -1,0 +1,71 @@
+package com.kt.mindLog.domain.session;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+
+import com.kt.mindLog.domain.user.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "crisis_logs")
+@NoArgsConstructor
+public class CrisisLogs {
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+	@Column(name = "log_id")
+	private UUID id;
+
+	@Column(name = "crisis_level")
+	private Integer level;
+
+	@Column(columnDefinition = "TEXT", name = "detected_keywords")
+	private List<String> keywords;
+
+	@Column(columnDefinition = "TEXT", name = "response_message")
+	private String message;
+
+	private LocalDateTime detectedAt;
+
+	@Column(name = "user_acknowledged", nullable = false)
+	private boolean isAcknowledged;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "session_id", nullable = false)
+	private Session session;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "message_id", nullable = false)
+	private SessionMessages messages;
+
+	@Builder
+	public CrisisLogs(Integer level, List<String> keywords, String message,
+		User user, Session session, SessionMessages messages) {
+		this.level = level;
+		this.keywords = keywords;
+		this.message = message;
+		this.detectedAt = LocalDateTime.now();
+		this.isAcknowledged = false;
+		this.user = user;
+		this.session = session;
+		this.messages = messages;
+	}
+}

--- a/src/main/java/com/kt/mindLog/domain/session/Session.java
+++ b/src/main/java/com/kt/mindLog/domain/session/Session.java
@@ -84,4 +84,13 @@ public class Session {
 	public void updateTitle(final String title) {
 		this.title = title;
 	}
+
+	public void updateStatus(final SessionStatus sessionStatus) {
+		this.status = sessionStatus;
+		this.endedAt = LocalDateTime.now();
+	}
+
+	public void updateTime() {
+		this.updatedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/kt/mindLog/domain/session/Session.java
+++ b/src/main/java/com/kt/mindLog/domain/session/Session.java
@@ -64,8 +64,12 @@ public class Session {
 	private List<SessionMessages> messages = new ArrayList<>();
 
 	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "summary_id", nullable = true)
+	@JoinColumn(name = "summary_id")
 	private SessionSummary summary;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "session_id")
+	private SessionContextSummary contextSummary;
 
 	@Builder
 	public Session(User user, Persona persona) {

--- a/src/main/java/com/kt/mindLog/domain/session/SessionContextSummary.java
+++ b/src/main/java/com/kt/mindLog/domain/session/SessionContextSummary.java
@@ -1,0 +1,41 @@
+package com.kt.mindLog.domain.session;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+
+import com.kt.mindLog.domain.user.User;
+import com.kt.mindLog.global.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "session_context_summaries")
+@NoArgsConstructor
+public class SessionContextSummary extends BaseEntity {
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+	@Column(name = "context_id")
+	private UUID id;
+
+	@Column(columnDefinition = "TEXT")
+	private String content;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "session_id", nullable = false)
+	private Session session;
+}

--- a/src/main/java/com/kt/mindLog/dto/session/response/ActiveSessionResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/session/response/ActiveSessionResponse.java
@@ -1,0 +1,24 @@
+package com.kt.mindLog.dto.session.response;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kt.mindLog.domain.session.Session;
+
+public record ActiveSessionResponse(
+	@JsonProperty("session_id")
+	String sessionId,
+
+	String title,
+
+	@JsonProperty("started_at")
+	LocalDateTime startedAt
+) {
+	public static ActiveSessionResponse from(Session session) {
+		return new ActiveSessionResponse(
+			session.getId().toString(),
+			session.getTitle(),
+			session.getStartedAt()
+		);
+	}
+}

--- a/src/main/java/com/kt/mindLog/dto/session/response/CrisisCheck.java
+++ b/src/main/java/com/kt/mindLog/dto/session/response/CrisisCheck.java
@@ -5,7 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record CrisisCheck (
-	boolean detected,
+	int level,
 	List<String> keywords,
 	@JsonProperty("suggested_response")
 	String suggestedResponse

--- a/src/main/java/com/kt/mindLog/dto/session/response/SessionDetailResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/session/response/SessionDetailResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kt.mindLog.domain.session.Session;
+import com.kt.mindLog.dto.sessionMessage.response.SessionMessageListResponse;
 
 public record SessionDetailResponse(
 	@JsonProperty("session_id")

--- a/src/main/java/com/kt/mindLog/dto/session/response/SessionEmotionResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/session/response/SessionEmotionResponse.java
@@ -1,0 +1,20 @@
+package com.kt.mindLog.dto.session.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SessionEmotionResponse(
+	@JsonProperty("emotion_type")
+	String emotionType,
+
+	Integer intensity,
+
+	@JsonProperty("source_keyword")
+	String sourceKeyword,
+
+	@JsonProperty("trigger_context")
+	String triggerContext,
+
+	@JsonProperty("emotion_trajectory")
+	String emotionTrajectory
+) {
+}

--- a/src/main/java/com/kt/mindLog/dto/session/response/SessionResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/session/response/SessionResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kt.mindLog.domain.session.Session;
+import com.kt.mindLog.dto.sessionMessage.response.SessionMessageResponse;
 
 public record SessionResponse (
 	@JsonProperty("session_id")

--- a/src/main/java/com/kt/mindLog/dto/sessionMessage/response/CrisisCheck.java
+++ b/src/main/java/com/kt/mindLog/dto/sessionMessage/response/CrisisCheck.java
@@ -1,4 +1,4 @@
-package com.kt.mindLog.dto.session.response;
+package com.kt.mindLog.dto.sessionMessage.response;
 
 import java.util.List;
 

--- a/src/main/java/com/kt/mindLog/dto/sessionMessage/response/SessionMessageListResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/sessionMessage/response/SessionMessageListResponse.java
@@ -1,4 +1,4 @@
-package com.kt.mindLog.dto.session.response;
+package com.kt.mindLog.dto.sessionMessage.response;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/kt/mindLog/dto/sessionMessage/response/SessionMessageResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/sessionMessage/response/SessionMessageResponse.java
@@ -1,4 +1,4 @@
-package com.kt.mindLog.dto.session.response;
+package com.kt.mindLog.dto.sessionMessage.response;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/kt/mindLog/dto/summary/response/SessionSummaryResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/summary/response/SessionSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.kt.mindLog.dto.summary.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kt.mindLog.dto.session.response.SessionEmotionResponse;
+
+import tools.jackson.databind.JsonNode;
+
+public record SessionSummaryResponse(
+	SummaryResponse summary,
+	@JsonProperty("context_summary")
+	String contextSummary,
+	List<SessionEmotionResponse> emotions,
+	JsonNode card
+) {
+}

--- a/src/main/java/com/kt/mindLog/dto/summary/response/SummaryResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/summary/response/SummaryResponse.java
@@ -1,0 +1,8 @@
+package com.kt.mindLog.dto.summary.response;
+
+public record SummaryResponse(
+	String fact,
+	String emotion,
+	String insight
+) {
+}

--- a/src/main/java/com/kt/mindLog/global/property/SessionProperties.java
+++ b/src/main/java/com/kt/mindLog/global/property/SessionProperties.java
@@ -9,5 +9,6 @@ import lombok.RequiredArgsConstructor;
 @ConfigurationProperties(prefix = "session")
 public class SessionProperties {
 	private final String baseurl;
-	private final String uri;
+	private final String messageUri;
+	private final String finalizeUri;
 }

--- a/src/main/java/com/kt/mindLog/repository/session/CrisisLogRepository.java
+++ b/src/main/java/com/kt/mindLog/repository/session/CrisisLogRepository.java
@@ -1,0 +1,10 @@
+package com.kt.mindLog.repository.session;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.kt.mindLog.domain.session.CrisisLogs;
+
+public interface CrisisLogRepository extends JpaRepository<CrisisLogs, UUID> {
+}

--- a/src/main/java/com/kt/mindLog/repository/session/SessionRepository.java
+++ b/src/main/java/com/kt/mindLog/repository/session/SessionRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kt.mindLog.domain.session.Session;
+import com.kt.mindLog.domain.session.SessionStatus;
 import com.kt.mindLog.global.common.exception.CustomException;
 import com.kt.mindLog.global.common.exception.ErrorCode;
 
@@ -21,4 +22,6 @@ public interface SessionRepository extends JpaRepository<Session,UUID> {
 	default Session findByIdAndUserIdOrThrow(UUID id, UUID userId, ErrorCode errorCode) {
 		return findByIdAndUserId(id, userId).orElseThrow(() -> new CustomException(errorCode));
 	}
+
+	Optional<Session> findFirstByUserIdAndStatusOrderByCreatedAtDesc(UUID userId, SessionStatus status);
 }

--- a/src/main/java/com/kt/mindLog/service/session/SessionMessageService.java
+++ b/src/main/java/com/kt/mindLog/service/session/SessionMessageService.java
@@ -1,6 +1,9 @@
 package com.kt.mindLog.service.session;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
@@ -16,9 +19,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import com.kt.mindLog.domain.session.CrisisLogs;
 import com.kt.mindLog.domain.session.SessionMessages;
+import com.kt.mindLog.domain.session.SessionStatus;
 import com.kt.mindLog.domain.user.Role;
 import com.kt.mindLog.domain.user.User;
-import com.kt.mindLog.dto.session.response.CrisisCheck;
+import com.kt.mindLog.dto.session.response.SessionEmotionResponse;
+import com.kt.mindLog.dto.sessionMessage.response.CrisisCheck;
+import com.kt.mindLog.dto.summary.response.SessionSummaryResponse;
 import com.kt.mindLog.global.common.exception.ErrorCode;
 import com.kt.mindLog.global.property.SessionProperties;
 import com.kt.mindLog.repository.SessionMessageRepository;
@@ -55,7 +61,7 @@ public class SessionMessageService {
 		AtomicReference<UUID> messageIdRef = new AtomicReference<>();
 
 		return webClient.post()
-			.uri(sessionProperties.getUri(), sessionId)
+			.uri(sessionProperties.getMessageUri(), sessionId)
 			.contentType(MediaType.APPLICATION_JSON)
 			.bodyValue(Map.of("content", contents))
 			.accept(MediaType.TEXT_EVENT_STREAM)
@@ -125,6 +131,9 @@ public class SessionMessageService {
 			.sequenceNum(sequence)
 			.build());
 
+		session.updateTime();
+		sessionRepository.save(session);
+
 		log.info("success to save session message");
 		return message.getId();
 	}
@@ -136,7 +145,7 @@ public class SessionMessageService {
 		userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
 
 		webClient.post()
-			.uri(sessionProperties.getUri(), sessionId)
+			.uri(sessionProperties.getMessageUri(), sessionId)
 			.contentType(MediaType.APPLICATION_JSON)
 			.bodyValue(Map.of("content", contents))
 			.accept(MediaType.TEXT_EVENT_STREAM)
@@ -199,5 +208,68 @@ public class SessionMessageService {
 
 		crisisLogRepository.saveAndFlush(crisis);
 		log.info("success to save crisis log");
+	}
+
+	public Flux<Object> finalizeSession(final UUID sessionId, final UUID userId) {
+		userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
+
+		return webClient.post()
+			.uri(sessionProperties.getFinalizeUri(), sessionId)
+			.contentType(MediaType.APPLICATION_JSON)
+			.accept(MediaType.TEXT_EVENT_STREAM)
+			.retrieve()
+			.onStatus(HttpStatusCode::isError, response ->
+				response.bodyToMono(String.class)
+					.map(body -> new RuntimeException("AI 서버 오류: " + body))
+			)
+			.bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
+			.timeout(Duration.ofMinutes(2))
+			.doOnNext(this::logEvent)
+			.handle((event, sink) -> {
+				switch (event.event()) {
+					case "status" -> sink.next(event);
+
+					case "session_title" -> saveTitle(sessionId, event.data());
+
+					case "ai_complete" -> {
+						var summary = objectMapper.readValue(event.data(), SessionSummaryResponse.class);
+
+						List<Map<String, Object>> emotions = new ArrayList<>();
+
+						for (SessionEmotionResponse response : summary.emotions()) {
+							Map<String, Object> emotionMap = new HashMap<>();
+							emotionMap.put("emotion_type", response.emotionType());
+							emotionMap.put("intensity", response.intensity());
+							emotionMap.put("source_keyword", response.sourceKeyword());
+
+							emotions.add(emotionMap);
+						}
+
+						sink.next(ServerSentEvent.builder()
+							.event("ai_complete")
+							.data(Map.of(
+								"session_id", sessionId.toString(),
+								"summary", summary.summary(),
+								"emotions", emotions,
+								"card_image_url", summary.card().get("image_url").asText()
+							))
+							.build());
+
+						updateSessionStatus(sessionId, SessionStatus.COMPLETED);
+
+						//TODO 마음기록카드 저장 + 요약 정보 저장 + 감정 저장 + 카드 저장
+						updateSessionStatus(sessionId, SessionStatus.SAVED);
+					}
+				}
+			})
+			.doOnError(e -> log.error("스트림 오류", e));
+	}
+
+	@Transactional
+	protected void updateSessionStatus(final UUID sessionId, final SessionStatus sessionStatus) {
+		var session =  sessionRepository.findByIdOrThrow(sessionId, ErrorCode.NOT_FOUND_SESSION);
+
+		session.updateStatus(sessionStatus);
+		sessionRepository.saveAndFlush(session);
 	}
 }

--- a/src/main/java/com/kt/mindLog/service/session/SessionMessageService.java
+++ b/src/main/java/com/kt/mindLog/service/session/SessionMessageService.java
@@ -14,12 +14,15 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.kt.mindLog.domain.session.CrisisLogs;
 import com.kt.mindLog.domain.session.SessionMessages;
 import com.kt.mindLog.domain.user.Role;
+import com.kt.mindLog.domain.user.User;
 import com.kt.mindLog.dto.session.response.CrisisCheck;
 import com.kt.mindLog.global.common.exception.ErrorCode;
 import com.kt.mindLog.global.property.SessionProperties;
 import com.kt.mindLog.repository.SessionMessageRepository;
+import com.kt.mindLog.repository.session.CrisisLogRepository;
 import com.kt.mindLog.repository.session.SessionRepository;
 import com.kt.mindLog.repository.UserRepository;
 import com.kt.mindLog.service.redis.RedisService;
@@ -38,6 +41,7 @@ public class SessionMessageService {
 	private final UserRepository userRepository;
 	private final SessionMessageRepository sessionMessageRepository;
 	private final SessionRepository sessionRepository;
+	private final CrisisLogRepository crisisLogRepository;
 
 	private final ObjectMapper objectMapper;
 	private final WebClient webClient;
@@ -47,7 +51,8 @@ public class SessionMessageService {
 
 
 	public Flux<Object> receiveSSE(final String contents, final UUID sessionId, final UUID userId) {
-		userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
+		var user = userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
+		AtomicReference<UUID> messageIdRef = new AtomicReference<>();
 
 		return webClient.post()
 			.uri(sessionProperties.getUri(), sessionId)
@@ -61,9 +66,9 @@ public class SessionMessageService {
 			)
 			.bodyToFlux(new ParameterizedTypeReference<ServerSentEvent<String>>() {})
 			.timeout(Duration.ofMinutes(2))
-			.doFirst(() -> saveContents(Role.USER, contents, sessionId))
+			.doFirst(() -> messageIdRef.set(saveContents(Role.USER, contents, sessionId)))
 			.doOnNext(this::logEvent)
-			.handle((event, sink) -> handleEvent(event, sink, sessionId))
+			.handle((event, sink) -> handleEvent(event, sink, sessionId, user, messageIdRef))
 			.doOnError(e -> log.error("스트림 오류", e));
 	}
 
@@ -71,20 +76,22 @@ public class SessionMessageService {
 		if ("error".equals(event.event())) {
 			log.error("AI error: {}", event.data());
 		} else {
-			log.info("event: {}, data: {}", event.event(), event.data());
+			log.info("event: {}, data: {}", event.event(), event.data()); //TODO 최종 배포 시 삭제
 		}
 	}
 
-	private void handleEvent(ServerSentEvent<String> event, SynchronousSink<Object> sink, UUID sessionId) {
+	private void handleEvent(ServerSentEvent<String> event, SynchronousSink<Object> sink, UUID sessionId, User user, AtomicReference<UUID> messageIdRef) {
 		switch (event.event()) {
 			case "ai_chunk" -> sink.next(event);
 
 			case "crisis_check" -> {
 				CrisisCheck crisis = objectMapper.readValue(event.data(), CrisisCheck.class);
-				if (crisis.detected()) {
+				if (crisis.level() >= 2) {
 					sink.next(ServerSentEvent.builder(Map.of("content", crisis.suggestedResponse()))
 						.event("crisis_check")
 						.build());
+
+					saveCrisis(sessionId, crisis, user, messageIdRef.get());
 				}
 			}
 
@@ -165,7 +172,7 @@ public class SessionMessageService {
 	}
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	protected void saveTitle(UUID sessionId, String contents) {
+	protected void saveTitle(final UUID sessionId, final String contents) {
 
 		var session = sessionRepository.findByIdOrThrow(sessionId, ErrorCode.NOT_FOUND_SESSION);
 		String title = parseJson(contents, "title");
@@ -173,5 +180,24 @@ public class SessionMessageService {
 
 		sessionRepository.saveAndFlush(session);
 		log.info("success to save session title");
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	protected void saveCrisis(final UUID sessionId, final CrisisCheck crisisCheck, final User user, UUID messageId) {
+		var session = sessionRepository.findByIdOrThrow(sessionId, ErrorCode.NOT_FOUND_SESSION);
+		var messages = sessionMessageRepository.findByIdOrThrow(UUID.fromString(messageId.toString()),
+			ErrorCode.NOT_FOUND_SESSION_MESSAGE);
+
+		var crisis = CrisisLogs.builder()
+			.level(crisisCheck.level())
+			.keywords(crisisCheck.keywords())
+			.message(crisisCheck.suggestedResponse())
+			.session(session)
+			.user(user)
+			.messages(messages)
+			.build();
+
+		crisisLogRepository.saveAndFlush(crisis);
+		log.info("success to save crisis log");
 	}
 }

--- a/src/main/java/com/kt/mindLog/service/session/SessionService.java
+++ b/src/main/java/com/kt/mindLog/service/session/SessionService.java
@@ -2,6 +2,7 @@ package com.kt.mindLog.service.session;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -10,7 +11,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kt.mindLog.domain.session.Session;
+import com.kt.mindLog.domain.session.SessionStatus;
 import com.kt.mindLog.dto.session.request.SessionCreateRequest;
+import com.kt.mindLog.dto.session.response.ActiveSessionResponse;
 import com.kt.mindLog.dto.session.response.SessionDetailResponse;
 import com.kt.mindLog.dto.session.response.SessionListResponse;
 import com.kt.mindLog.dto.session.response.SessionListResponses;
@@ -99,5 +102,13 @@ public class SessionService {
 		var hasSummary = session.getSummary() != null;
 
 		return SessionDetailResponse.from(session, sessionMessages, hasSummary);
+	}
+
+	public ActiveSessionResponse getActiveSession(final UUID userId) {
+		userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
+
+		Optional<Session> session = sessionRepository.findFirstByUserIdAndStatusOrderByCreatedAtDesc(userId, SessionStatus.ACTIVE);
+
+		return session.map(ActiveSessionResponse::from).orElse(null);
 	}
 }

--- a/src/main/java/com/kt/mindLog/service/session/SessionService.java
+++ b/src/main/java/com/kt/mindLog/service/session/SessionService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import com.kt.mindLog.domain.session.Session;
 import com.kt.mindLog.domain.session.SessionStatus;
@@ -17,11 +18,12 @@ import com.kt.mindLog.dto.session.response.ActiveSessionResponse;
 import com.kt.mindLog.dto.session.response.SessionDetailResponse;
 import com.kt.mindLog.dto.session.response.SessionListResponse;
 import com.kt.mindLog.dto.session.response.SessionListResponses;
-import com.kt.mindLog.dto.session.response.SessionMessageListResponse;
-import com.kt.mindLog.dto.session.response.SessionMessageResponse;
+import com.kt.mindLog.dto.sessionMessage.response.SessionMessageListResponse;
+import com.kt.mindLog.dto.sessionMessage.response.SessionMessageResponse;
 import com.kt.mindLog.dto.session.response.SessionResponse;
 import com.kt.mindLog.global.common.exception.ErrorCode;
 import com.kt.mindLog.global.common.response.Pagination;
+import com.kt.mindLog.global.property.SessionProperties;
 import com.kt.mindLog.repository.PersonaRepository;
 import com.kt.mindLog.repository.SessionMessageRepository;
 import com.kt.mindLog.repository.session.SessionRepository;
@@ -30,6 +32,7 @@ import com.kt.mindLog.repository.session.SessionRepositoryCustom;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Service
@@ -38,9 +41,15 @@ public class SessionService {
 	private final SessionRepository sessionRepository;
 	private final UserRepository userRepository;
 	private final PersonaRepository personaRepository;
-	private final SessionMessageService sessionMessageService;
 	private final SessionMessageRepository sessionMessageRepository;
 	private final SessionRepositoryCustom sessionRepositoryCustom;
+
+	private final SessionMessageService sessionMessageService;
+
+	private final ObjectMapper objectMapper;
+	private final WebClient webClient;
+	private final SessionProperties sessionProperties;
+
 
 	public SessionResponse saveSession(final UUID userId, final SessionCreateRequest request) {
 		var newSession = createSession(userId, request);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,9 +60,3 @@ cors:
 
 server:
   port: 8080
-
-cloud:
-  aws:
-    region: ap-northeast-2
-    s3:
-      bucket: ${AWS_S3_BUCKET_NAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,3 +60,9 @@ cors:
 
 server:
   port: 8080
+
+cloud:
+  aws:
+    region: ap-northeast-2
+    s3:
+      bucket: ${AWS_S3_BUCKET_NAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,7 +51,8 @@ google:
 
 session:
   baseurl: ${SESSION_BASE_URL}
-  uri: ${SESSION_URI}
+  message-uri: ${SESSION_MESSAGE_URI}
+  finalize-uri: ${SESSION_FINALIZE_URI}
 
 cors:
   local: ${CORS_LOCAL_URL}


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #14 


## 🔨변경 사항(Changes)
- 미종료 세션 여부 확인 API 구현
- 상담 종료 API 구현
- crisis log 테이블 저장


## 😉리뷰 요구사항
- 문제 없이 로직이 작동하는지 확인 부탁드리겠습니다.
- 상담 종료 API는 현재 상담 결과 저장 및 마음기록 카드 저장 로직이 구현되지 않은 상황입니다. 
  이를 감안하여 검토 부탁드리겠습니다 :)
- 환경 변수가 추가되었습니다. 갱신 후 테스트 부탁드리겠습니다 ~


<br/>
