### PR TITLE
feat: implement paid credit refund and transaction cancel logic

### DIFF
--- a/src/main/java/com/kt/mindLog/controller/payment/PaymentController.java
+++ b/src/main/java/com/kt/mindLog/controller/payment/PaymentController.java
@@ -1,0 +1,31 @@
+package com.kt.mindLog.controller.payment;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kt.mindLog.global.common.response.ApiResult;
+import com.kt.mindLog.service.payment.PaymentService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/payments")
+public class PaymentController {
+	private final PaymentService paymentService;
+
+	@PostMapping("/{paymentId}/cancel")
+	public ApiResult<UUID> refund(@PathVariable UUID paymentId) {
+		paymentService.refund(paymentId);
+
+		return ApiResult.ok(paymentId);
+	}
+
+
+}

--- a/src/main/java/com/kt/mindLog/domain/credit/Credit.java
+++ b/src/main/java/com/kt/mindLog/domain/credit/Credit.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,6 +26,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "credits")
 @NoArgsConstructor
+@AllArgsConstructor
 public class Credit {
 	@Id
 	@UuidGenerator(style = UuidGenerator.Style.VERSION_7)
@@ -56,13 +58,16 @@ public class Credit {
 	private int balanceAfter; // 거래 후 잔액 (무료 + 유료 크레딧)
 
 	@Column(nullable = false)
+	private int remainingPaidCredit = 0; // 남아있는 유료 크레딧 잔액
+
+	@Column(nullable = false)
 	private LocalDateTime createdAt;
 
 	private String description;
 
 	@Builder
 	private Credit(User user, Payment payment, TransactionType transactionType, int freeCredit, int paidCredit,
-		int amount, int balanceAfter, String description) {
+		int amount, int balanceAfter, int remainingPaidCredit, String description) {
 		this.user = user;
 		this.payment = payment;
 		this.transactionType = transactionType;
@@ -70,6 +75,7 @@ public class Credit {
 		this.paidCredit = paidCredit;
 		this.amount = amount;
 		this.balanceAfter = balanceAfter;
+		this.remainingPaidCredit = remainingPaidCredit;
 		this.description = description;
 		this.createdAt = LocalDateTime.now();
 	}
@@ -79,6 +85,7 @@ public class Credit {
 		TransactionType transactionType,
 		int amount,
 		int balanceAfter,
+		int remainingPaidCredit,
 		String description
 	) {
 		return Credit.builder()
@@ -88,6 +95,7 @@ public class Credit {
 			.freeCredit(amount)
 			.paidCredit(0)
 			.balanceAfter(balanceAfter)
+			.remainingPaidCredit(remainingPaidCredit)
 			.description(description)
 			.build();
 	}
@@ -99,6 +107,7 @@ public class Credit {
 		int freeUsed, // 차감할 무료 크레딧
 		int paidUsed, // 차감할 유료 크레딧
 		int balanceAfter,
+		int remainingPaidCredit,
 		String description
 	){
 		return Credit.builder()
@@ -108,6 +117,7 @@ public class Credit {
 			.paidCredit(-paidUsed)
 			.amount(-amount)
 			.balanceAfter(balanceAfter)
+			.remainingPaidCredit(remainingPaidCredit)
 			.description(description)
 			.build();
 	}
@@ -123,10 +133,19 @@ public class Credit {
 			.payment(payment)
 			.transactionType(TransactionType.CHARGE)
 			.amount(amount)
+			.remainingPaidCredit(amount)
 			.freeCredit(0)
 			.paidCredit(amount)
 			.balanceAfter(balanceAfter)
 			.description("유료 크레딧 충전")
 			.build();
+	}
+
+	public void deductRemainingPaidCredit(int amount) {
+		this.remainingPaidCredit -= amount;
+	}
+
+	public void deductPaidCredit(int amount) {
+		this.paidCredit -= amount;
 	}
 }

--- a/src/main/java/com/kt/mindLog/domain/payment/Payment.java
+++ b/src/main/java/com/kt/mindLog/domain/payment/Payment.java
@@ -7,6 +7,9 @@ import org.hibernate.annotations.UuidGenerator;
 
 import com.kt.mindLog.domain.session.SessionStatus;
 import com.kt.mindLog.domain.user.User;
+import com.kt.mindLog.global.common.exception.CustomException;
+import com.kt.mindLog.global.common.exception.ErrorCode;
+import com.kt.mindLog.global.common.support.Preconditions;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,6 +20,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -49,11 +53,39 @@ public class Payment {
 	@Column(nullable = false)
 	private PaymentStatus status;
 
-	private String failReason;
-
 	private LocalDateTime approvedAt;
 
 	@Column(nullable = false)
 	private LocalDateTime createdAt;
+
+	public boolean isCanceled() {
+		return this.status == PaymentStatus.CANCELED;
+	}
+
+	public void complete() {
+		if (this.status != PaymentStatus.IN_PROGRESS) {
+			throw new CustomException(ErrorCode.INVALID_PAYMENT_STATUS);
+		}
+		this.status = PaymentStatus.DONE;
+	}
+
+	public void fail() {
+		this.status = PaymentStatus.FAILED;
+	}
+
+	public void cancel() {
+		this.status = PaymentStatus.CANCELED;
+	}
+
+	@Builder
+	private Payment(User user, String orderId, String paymentKey, int amount, String orderName) {
+		this.user = user;
+		this.orderId = orderId;
+		this.paymentKey = paymentKey;
+		this.amount = amount;
+		this.orderName = orderName;
+		this.status = PaymentStatus.READY;
+		this.createdAt = LocalDateTime.now();
+	}
 
 }

--- a/src/main/java/com/kt/mindLog/domain/payment/PaymentStatus.java
+++ b/src/main/java/com/kt/mindLog/domain/payment/PaymentStatus.java
@@ -1,5 +1,9 @@
 package com.kt.mindLog.domain.payment;
 
 public enum PaymentStatus {
-	READY, DONE, FAILED
+	READY, // 결제 생성
+	IN_PROGRESS, // 결제 승인 요청 보냈을 때
+	DONE, // 결제 성공
+	FAILED, // 결제 실패
+	CANCELED // 결제 취소
 }

--- a/src/main/java/com/kt/mindLog/global/client/TossClient.java
+++ b/src/main/java/com/kt/mindLog/global/client/TossClient.java
@@ -2,15 +2,19 @@ package com.kt.mindLog.global.client;
 
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
-@RequiredArgsConstructor
 public class TossClient {
 	private final WebClient tossClient;
+
+	public TossClient(@Qualifier("tossWebClient") WebClient tossClient) {
+		this.tossClient = tossClient;
+	}
 
 	public void refund(String paymentKey) {
 		tossClient.post()

--- a/src/main/java/com/kt/mindLog/global/client/TossClient.java
+++ b/src/main/java/com/kt/mindLog/global/client/TossClient.java
@@ -1,0 +1,23 @@
+package com.kt.mindLog.global.client;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TossClient {
+	private final WebClient tossClient;
+
+	public void refund(String paymentKey) {
+		tossClient.post()
+			.uri("/v1/payments/{paymentId}/cancel", paymentKey)
+			.bodyValue(Map.of("cancelReason", "고객 환불 요청"))
+			.retrieve()
+			.bodyToMono(Void.class)
+			.block();
+	}
+}

--- a/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
@@ -49,8 +49,13 @@ public enum ErrorCode {
 	NOT_FOUND_SUMMARY(HttpStatus.BAD_REQUEST, "해당 세션 요약 컨텍스트를 찾을 수 없습니다."),
 
 	// credit
-	ATTENDANCE_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "출석 체크는 하루에 1회만 가능합니다."),
-	INSUFFICIENT_CREDIT(HttpStatus.BAD_REQUEST, "크레딧이 부족합니다.")
+	ALREADY_USED_CREDIT(HttpStatus.BAD_REQUEST, "이미 사용된 크레딧입니다."),
+	INSUFFICIENT_CREDIT(HttpStatus.BAD_REQUEST, "크레딧이 부족합니다."),
+
+	// payment
+	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "결제 정보를 찾을 수 없습니다."),
+	ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 결제입니다."),
+	INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "결제 진행 중 상태가 아닙니다.")
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/kt/mindLog/global/config/TossClientConfig.java
+++ b/src/main/java/com/kt/mindLog/global/config/TossClientConfig.java
@@ -1,0 +1,32 @@
+package com.kt.mindLog.global.config;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.kt.mindLog.global.property.TossProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class TossClientConfig {
+	private final TossProperties tossProperties;
+
+	@Bean
+	public WebClient tossWebClient() {
+		return WebClient.builder()
+			.baseUrl(tossProperties.getBaseUrl())
+			.defaultHeader("Authorization", "Basic " + encode(tossProperties.getSecretKey()))
+			.defaultHeader("Content-Type", "application/json")
+			.build();
+	}
+
+	private String encode(String secretKey) {
+		return Base64.getEncoder()
+			.encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/src/main/java/com/kt/mindLog/global/property/TossProperties.java
+++ b/src/main/java/com/kt/mindLog/global/property/TossProperties.java
@@ -1,0 +1,13 @@
+package com.kt.mindLog.global.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+
+@ConfigurationProperties(prefix = "toss")
+@Getter
+public class TossProperties {
+	private String baseUrl;
+	private String clientKey;
+	private String secretKey;
+}

--- a/src/main/java/com/kt/mindLog/global/property/TossProperties.java
+++ b/src/main/java/com/kt/mindLog/global/property/TossProperties.java
@@ -2,10 +2,12 @@ package com.kt.mindLog.global.property;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @ConfigurationProperties(prefix = "toss")
 @Getter
+@AllArgsConstructor
 public class TossProperties {
 	private String baseUrl;
 	private String clientKey;

--- a/src/main/java/com/kt/mindLog/repository/payment/PaymentRepository.java
+++ b/src/main/java/com/kt/mindLog/repository/payment/PaymentRepository.java
@@ -1,0 +1,18 @@
+package com.kt.mindLog.repository.payment;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.kt.mindLog.domain.payment.Payment;
+import com.kt.mindLog.global.common.exception.CustomException;
+import com.kt.mindLog.global.common.exception.ErrorCode;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, UUID> {
+	default Payment findByIdOrThrow(UUID id, ErrorCode errorCode) {
+		return findById(id).orElseThrow(() -> new CustomException(errorCode));
+	}
+
+}

--- a/src/main/java/com/kt/mindLog/service/credit/CreditService.java
+++ b/src/main/java/com/kt/mindLog/service/credit/CreditService.java
@@ -18,16 +18,16 @@ import com.kt.mindLog.global.common.exception.ErrorCode;
 import com.kt.mindLog.global.common.support.Preconditions;
 import com.kt.mindLog.repository.UserRepository;
 import com.kt.mindLog.repository.credit.CreditRepository;
-import com.kt.mindLog.repository.session.SessionRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CreditService {
 	private final CreditRepository creditRepository;
 	private final UserRepository userRepository;
-	private final SessionRepository sessionRepository;
 
 	private static final int SIGNUP_BONUS = 150;
 	private static final int ATTENDANCE_BONUS = 3;
@@ -41,6 +41,7 @@ public class CreditService {
 			TransactionType.SIGNUP_BONUS,
 			SIGNUP_BONUS,
 			SIGNUP_BONUS,
+			0,
 			"회원가입 보너스 지급"
 		);
 
@@ -61,7 +62,10 @@ public class CreditService {
 				endOfToday
 			);
 
-		Preconditions.validate(!alreadyChecked, ErrorCode.ATTENDANCE_ALREADY_COMPLETED);
+		if (alreadyChecked) {
+			log.info("이미 출석 체크 완료 userId={}", user.getId());
+			return;
+		}
 
 		int currentFree = creditRepository.sumFreeCreditByUserId(user.getId());
 		int currentPaid = creditRepository.sumPaidCreditByUserId(user.getId());
@@ -74,6 +78,7 @@ public class CreditService {
 			TransactionType.ATTENDANCE_CHECK,
 			ATTENDANCE_BONUS,
 			balanceAfter,
+			currentPaid,
 			"출석체크 보너스 지급"
 		);
 
@@ -97,6 +102,7 @@ public class CreditService {
 			TransactionType.SAVE_SESSION,
 			SAVE_SESSION,
 			balanceAfter,
+			currentPaid,
 			"세션 저장 보너스 지급"
 		);
 
@@ -114,7 +120,7 @@ public class CreditService {
 		int total = currentFree + currentPaid;
 
 		// 크레딧 체크
-		Preconditions.validate(!(total < EXTRA_SESSION), ErrorCode.INSUFFICIENT_CREDIT);
+		Preconditions.validate(total >= EXTRA_SESSION, ErrorCode.INSUFFICIENT_CREDIT);
 
 		// 무료 크레딧 최대 사용
 		int freeUsed = Math.min(currentFree, EXTRA_SESSION);
@@ -130,6 +136,7 @@ public class CreditService {
 			freeUsed,
 			paidUsed,
 			balanceAfter,
+			currentPaid - paidUsed,
 			"추가 상담 크레딧 차감"
 		);
 
@@ -153,5 +160,50 @@ public class CreditService {
 			CreditProductResponse.of("중형", 500, 4900),
 			CreditProductResponse.of("대형", 1200, 10900)
 		);
+	}
+
+	public void validateRefundable(UUID paymentId) {
+		List<Credit> credits = creditRepository.findByPaymentId(paymentId);
+
+		for (Credit credit : credits) {
+			boolean isUsed = credit.getRemainingPaidCredit() < credit.getPaidCredit();
+
+			Preconditions.validate(!isUsed, ErrorCode.ALREADY_USED_CREDIT);
+		}
+	}
+
+	public void revokePaidCredits(UUID paymentId) {
+		List<Credit> credits = creditRepository.findByPaymentId(paymentId);
+
+		if (credits.isEmpty()) return;
+
+		UUID userId = credits.get(0).getUser().getId();
+
+		int currentPaid = creditRepository.sumPaidCreditByUserId(userId);
+		int currentFree = creditRepository.sumFreeCreditByUserId(userId);
+
+		for (Credit credit : credits) {
+			int usedPaid = credit.getPaidCredit() - credit.getRemainingPaidCredit();
+			Preconditions.validate(usedPaid == 0, ErrorCode.ALREADY_USED_CREDIT);
+
+			int refundAmount = credit.getRemainingPaidCredit();
+
+			currentPaid -= refundAmount;
+			int balanceAfter = currentFree + currentPaid;
+
+			Credit refund = Credit.builder()
+				.user(credit.getUser())
+				.payment(credit.getPayment())
+				.transactionType(TransactionType.REFUND)
+				.amount(-refundAmount)
+				.paidCredit(-refundAmount)
+				.freeCredit(0)
+				.remainingPaidCredit(0)
+				.balanceAfter(balanceAfter)
+				.description("유료 크레딧 환불")
+				.build();
+
+			creditRepository.save(refund);
+		}
 	}
 }

--- a/src/main/java/com/kt/mindLog/service/payment/PaymentService.java
+++ b/src/main/java/com/kt/mindLog/service/payment/PaymentService.java
@@ -34,6 +34,7 @@ public class PaymentService {
 
 		// 토스 환불
 		// tossClient.refund(payment.getPaymentKey());
+		// TODO: 토스 페이먼츠 연동
 
 		// 크레딧 회수
 		creditService.revokePaidCredits(paymentId);

--- a/src/main/java/com/kt/mindLog/service/payment/PaymentService.java
+++ b/src/main/java/com/kt/mindLog/service/payment/PaymentService.java
@@ -1,0 +1,44 @@
+package com.kt.mindLog.service.payment;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.mindLog.domain.payment.Payment;
+import com.kt.mindLog.global.client.TossClient;
+import com.kt.mindLog.global.common.exception.ErrorCode;
+import com.kt.mindLog.global.common.support.Preconditions;
+import com.kt.mindLog.repository.payment.PaymentRepository;
+import com.kt.mindLog.service.credit.CreditService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+	private final CreditService creditService;
+	private final PaymentRepository paymentRepository;
+
+	private final TossClient tossClient;
+
+	@Transactional
+	public void refund(UUID paymentId) {
+		Payment payment = paymentRepository.findByIdOrThrow(paymentId, ErrorCode.NOT_FOUND_PAYMENT);
+
+		// 이미 환불된 결제인지 검증
+		Preconditions.validate(!payment.isCanceled(), ErrorCode.ALREADY_CANCELED);
+
+		// 이미 사용된 크레딧 있는지 검증
+		creditService.validateRefundable(paymentId);
+
+		// 토스 환불
+		// tossClient.refund(payment.getPaymentKey());
+
+		// 크레딧 회수
+		creditService.revokePaidCredits(paymentId);
+
+		// 결제 상태 변경
+		payment.cancel();
+	}
+}


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #22 #26 


## 🔨변경 사항(Changes)
-유료 크레딧 환불 로직 + 결제 취소 구현
-Toss Payments 연동 설정
-Payment 도메인 수정 (failReason 삭제)
-Credit 도메인 수정 (remainingPaidCredit 추가)
-로그인 후 자동 출석체크 과정에서 이미 로그인한 유저가 로그인이 차단되는 문제 발생 > 수정 완료

## 😉리뷰 요구사항
환불 흐름이 자연스러운지 검토 부탁드립니다


<br/>
