### PR TITLE
feat: implement logout logic

### DIFF
--- a/src/main/java/com/kt/mindLog/controller/auth/AuthController.java
+++ b/src/main/java/com/kt/mindLog/controller/auth/AuthController.java
@@ -1,4 +1,60 @@
 package com.kt.mindLog.controller.auth;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kt.mindLog.domain.user.LoginType;
+import com.kt.mindLog.dto.oauth.request.LogoutRequest;
+import com.kt.mindLog.dto.user.response.LoginResponse;
+import com.kt.mindLog.global.common.response.ApiResult;
+import com.kt.mindLog.service.auth.AuthService;
+import com.kt.mindLog.service.user.JwtService;
+import com.kt.mindLog.service.user.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/auth")
 public class AuthController {
+
+	private final AuthService AuthService;
+	private final UserService userService;
+	private final JwtService jwtService;
+
+	// KAKAO
+	@GetMapping("/kakao/callback")
+	public LoginResponse kakaoLogin(@RequestParam("code") String code) {
+		String accessToken = AuthService.getAccessTokenFromKakao(code);
+		String email = AuthService.getKakaoUserInfo(accessToken);
+
+		return userService.login(email, LoginType.KAKAO);
+	}
+
+	// GOOGLE
+	@GetMapping("/google/callback")
+	public LoginResponse googleLogin(@RequestParam("code") String code) {
+		String accessToken = AuthService.getAccessTokenFromGoogle(code);
+		String email = AuthService.getGoogleUserInfo(accessToken);
+
+		return userService.login(email, LoginType.GOOGLE);
+	}
+
+	@GetMapping("/refresh")
+	public LoginResponse reissue(@RequestParam String refreshToken) {
+		return jwtService.reissueToken(refreshToken);
+	}
+
+	@PostMapping("/logout")
+	public ApiResult<Void> logout(@RequestBody LogoutRequest request) {
+		jwtService.logout(request.refreshToken());
+
+		return ApiResult.ok();
+	}
+
+
 }

--- a/src/main/java/com/kt/mindLog/controller/auth/AuthController.java
+++ b/src/main/java/com/kt/mindLog/controller/auth/AuthController.java
@@ -1,0 +1,4 @@
+package com.kt.mindLog.controller.auth;
+
+public class AuthController {
+}

--- a/src/main/java/com/kt/mindLog/dto/oauth/request/LogoutRequest.java
+++ b/src/main/java/com/kt/mindLog/dto/oauth/request/LogoutRequest.java
@@ -1,4 +1,6 @@
 package com.kt.mindLog.dto.oauth.request;
 
-public record LogoutRequest() {
+public record LogoutRequest(
+	String refreshToken
+) {
 }

--- a/src/main/java/com/kt/mindLog/dto/oauth/request/LogoutRequest.java
+++ b/src/main/java/com/kt/mindLog/dto/oauth/request/LogoutRequest.java
@@ -1,0 +1,4 @@
+package com.kt.mindLog.dto.oauth.request;
+
+public record LogoutRequest() {
+}

--- a/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 	INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 접근입니다. 다시 로그인을 시도해주시기 바랍니다."),
 	EXPIRED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "만료된 토큰입니다. 다시 로그인을 시도해주시기 바랍니다."),
 	INVALID_JWT_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "잘못된 형식의 JWT 토큰입니다."),
+	INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 리프레시 토큰입니다."),
 
 	// user
 	NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 회원입니다."),

--- a/src/main/java/com/kt/mindLog/global/config/SecurityConfig.java
+++ b/src/main/java/com/kt/mindLog/global/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
 	private final CorsProperties corsProperties;
 
 	private static final String[] GET_PERMIT_ALL = {"/actuator/**", "/v1/auth/**"};
-	private static final String[] POST_PERMIT_ALL = {"/internal/v1/sessions/**", "/v1/sessions/**"};
+	private static final String[] POST_PERMIT_ALL = {"/internal/v1/sessions/**", "/v1/sessions/**", "/v1/auth/logout"};
 	private static final String[] PATCH_PERMIT_ALL = {"/"};
 	private static final String[] PUT_PERMIT_ALL = {"/"};
 

--- a/src/main/java/com/kt/mindLog/global/security/JwtFilter.java
+++ b/src/main/java/com/kt/mindLog/global/security/JwtFilter.java
@@ -54,4 +54,9 @@ public class JwtFilter extends OncePerRequestFilter {
 
 		filterChain.doFilter(request, response);
 	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return request.getServletPath().equals("/v1/auth/logout");
+	}
 }

--- a/src/main/java/com/kt/mindLog/repository/JwtTokenRepository.java
+++ b/src/main/java/com/kt/mindLog/repository/JwtTokenRepository.java
@@ -14,4 +14,6 @@ public interface JwtTokenRepository extends JpaRepository<JwtToken, UUID> {
 	Optional<JwtToken> findByRefreshToken(String token);
 
 	void deleteByExpiresAtBefore(LocalDateTime now);
+
+	void deleteByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/kt/mindLog/repository/credit/CreditRepository.java
+++ b/src/main/java/com/kt/mindLog/repository/credit/CreditRepository.java
@@ -1,4 +1,26 @@
 package com.kt.mindLog.repository.credit;
 
-public interface CreditRepository {
+import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.kt.mindLog.domain.credit.Credit;
+import com.kt.mindLog.domain.credit.TransactionType;
+
+public interface CreditRepository extends JpaRepository<Credit, UUID> {
+	boolean existsByUserIdAndTransactionTypeAndCreatedAtBetween(UUID userId, TransactionType transactionType,
+		LocalDateTime start, LocalDateTime end);
+
+	// 무료 크레딧 합계 (null 대신 0 반환)
+	@Query("SELECT COALESCE(SUM(c.freeCredit), 0) FROM Credit c WHERE c.user.id = :userId")
+	int sumFreeCreditByUserId(UUID userId);
+
+	// 유료 크레딧 합계 (null 대신 0 반환)
+	@Query("SELECT COALESCE(SUM(c.paidCredit), 0) FROM Credit c WHERE c.user.id = :userId")
+	int sumPaidCreditByUserId(UUID userId);
+
+	List<Credit> findByPaymentId(UUID paymentId);
 }

--- a/src/main/java/com/kt/mindLog/repository/credit/CreditRepository.java
+++ b/src/main/java/com/kt/mindLog/repository/credit/CreditRepository.java
@@ -1,0 +1,4 @@
+package com.kt.mindLog.repository.credit;
+
+public interface CreditRepository {
+}

--- a/src/main/java/com/kt/mindLog/service/user/JwtService.java
+++ b/src/main/java/com/kt/mindLog/service/user/JwtService.java
@@ -71,4 +71,14 @@ public class JwtService {
 		jwtTokenRepository.deleteByExpiresAtBefore(LocalDateTime.now());
 		log.info("deleted expired tokens");
 	}
+
+	@Transactional
+	public void logout(String refreshToken) {
+		if (refreshToken == null || refreshToken.isBlank()) {
+			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+		}
+
+		jwtTokenRepository.deleteByRefreshToken(refreshToken);
+		log.info("logout success");
+	}
 }


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #44


## 🔨변경 사항(Changes)
-누락된 코드 복구 (authController, creditRepository)
-로그아웃 기능 구현

## 😉리뷰 요구사항
현재 구조상 로그아웃 시 refreshToken만 서버에서 삭제되고 accessToken은 만료 전까지는 유효한 상태입니다

그래서 로그아웃 이후에는 프론트에서 accessToken / refreshToken을 모두 삭제해서 이후 요청이 나가지 않도록 처리하는 방향은 어떻게 생각하시나요?




<br/>
