### PR TITLE
refactor: revise external API error handling logic

### DIFF
--- a/src/main/java/com/kt/mindLog/controller/payment/PaymentController.java
+++ b/src/main/java/com/kt/mindLog/controller/payment/PaymentController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.mindLog.dto.payment.request.PaymentConfirmRequest;
 import com.kt.mindLog.dto.payment.request.PaymentCreateRequest;
+import com.kt.mindLog.dto.payment.response.PaymentConfirmResponse;
 import com.kt.mindLog.dto.payment.response.PaymentCreateResponse;
 import com.kt.mindLog.dto.payment.response.PaymentListResponse;
 import com.kt.mindLog.global.annotation.Login;
@@ -42,9 +43,9 @@ public class PaymentController {
 	}
 
 	@PostMapping("/confirm")
-	public ApiResult<Void> confirmPayment(@RequestBody PaymentConfirmRequest request) {
+	public ApiResult<PaymentConfirmResponse> confirmPayment(@RequestBody PaymentConfirmRequest request) {
 		paymentService.confirm(request);
-		return ApiResult.ok();
+		return ApiResult.ok(paymentService.confirm(request));
 	}
 
 	@PostMapping

--- a/src/main/java/com/kt/mindLog/dto/payment/response/PaymentConfirmResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/payment/response/PaymentConfirmResponse.java
@@ -1,0 +1,19 @@
+package com.kt.mindLog.dto.payment.response;
+
+import java.time.OffsetDateTime;
+
+public record PaymentConfirmResponse(
+	String orderId,
+	int amount,
+	String status,
+	OffsetDateTime approvedAt
+) {
+	public static PaymentConfirmResponse from(TossPaymentResponse response) {
+		return new PaymentConfirmResponse(
+			response.orderId(),
+			response.totalAmount(),
+			response.status(),
+			response.approvedAt()
+		);
+	}
+}

--- a/src/main/java/com/kt/mindLog/dto/payment/response/TossPaymentResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/payment/response/TossPaymentResponse.java
@@ -1,12 +1,12 @@
 package com.kt.mindLog.dto.payment.response;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 public record TossPaymentResponse(
 	String paymentKey,
 	String orderId,
 	int totalAmount,
 	String status,
-	LocalDateTime approvedAt
+	OffsetDateTime approvedAt
 ) {
 }

--- a/src/main/java/com/kt/mindLog/global/client/TossClient.java
+++ b/src/main/java/com/kt/mindLog/global/client/TossClient.java
@@ -3,14 +3,19 @@ package com.kt.mindLog.global.client;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.kt.mindLog.dto.payment.response.TossPaymentResponse;
+import com.kt.mindLog.global.common.exception.CustomException;
+import com.kt.mindLog.global.common.exception.ErrorCode;
 
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
 
 @Component
+@Slf4j
 public class TossClient {
 	private final WebClient tossClient;
 
@@ -23,6 +28,13 @@ public class TossClient {
 			.uri("/v1/payments/{paymentId}/cancel", paymentKey)
 			.bodyValue(Map.of("cancelReason", "고객 환불 요청"))
 			.retrieve()
+			.onStatus(HttpStatusCode::isError, clientResponse ->
+				clientResponse.bodyToMono(String.class)
+					.flatMap(body -> {
+						log.error("Toss refund error: status={}, body={}", clientResponse.statusCode(), body);
+						return Mono.error(new CustomException(ErrorCode.TOSS_REFUND_FAILED));
+					})
+			)
 			.bodyToMono(Void.class)
 			.block();
 	}
@@ -36,6 +48,13 @@ public class TossClient {
 				"amount", amount
 			))
 			.retrieve()
+			.onStatus(HttpStatusCode::isError, clientResponse ->
+				clientResponse.bodyToMono(String.class)
+					.flatMap(body -> {
+						log.error("Toss confirm error: status={}, body={}", clientResponse.statusCode(), body);
+						return Mono.error(new CustomException(ErrorCode.TOSS_CONFIRM_FAILED));
+					})
+			)
 			.bodyToMono(TossPaymentResponse.class)
 			.block();
 	}

--- a/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
@@ -61,6 +61,8 @@ public enum ErrorCode {
 	PAYMENT_NOT_READY(HttpStatus.BAD_REQUEST, "결제가 준비 상태가 아닙니다."),
 	PAYMENT_NOT_DONE(HttpStatus.BAD_REQUEST, "결제가 완료된 상태가 아닙니다."),
 	ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 결제입니다."),
+	TOSS_CONFIRM_FAILED(HttpStatus.BAD_REQUEST, "토스 결제 승인에 실패했습니다."),
+	TOSS_REFUND_FAILED(HttpStatus.BAD_REQUEST, "토스 결제 환불에 실패했습니다."),
 
 	//report
 	INSUFFICIENT_SESSIONS(HttpStatus.BAD_REQUEST, "최소 상담 기록 횟수가 부족합니다"),

--- a/src/main/java/com/kt/mindLog/service/auth/AuthService.java
+++ b/src/main/java/com/kt/mindLog/service/auth/AuthService.java
@@ -17,10 +17,12 @@ import com.kt.mindLog.global.property.GoogleProperties;
 import com.kt.mindLog.global.property.KakaoProperties;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class AuthService {
 	private final KakaoProperties kakaoProperties;
 	private final GoogleProperties googleProperties;
@@ -60,10 +62,19 @@ public class AuthService {
 				.with("redirect_uri", kakaoProperties.getRedirectUri())
 				.with("code", code))
 			.retrieve()
-			.onStatus(HttpStatusCode::isError,
-				clientResponse -> Mono.error(new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED)))
+			.onStatus(HttpStatusCode::isError, clientResponse ->
+				clientResponse.bodyToMono(String.class)
+					.flatMap(body -> {
+						log.error("Kakao API error: status={}, body={}", clientResponse.statusCode(), body);
+						return Mono.error(new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED));
+					})
+			)
 			.bodyToMono(KakaoTokenResponse.class)
 			.block();
+
+		if (response == null) {
+			throw new CustomException(ErrorCode.KAKAO_TOKEN_REQUEST_FAILED);
+		}
 
 		return response.accessToken();
 	}
@@ -99,10 +110,19 @@ public class AuthService {
 				.with("redirect_uri", googleProperties.getRedirectUri())
 				.with("code", code))
 			.retrieve()
-			.onStatus(HttpStatusCode::isError,
-				clientResponse -> Mono.error(new CustomException(ErrorCode.GOOGLE_TOKEN_REQUEST_FAILED)))
+			.onStatus(HttpStatusCode::isError, clientResponse ->
+				clientResponse.bodyToMono(String.class)
+					.flatMap(body -> {
+						log.error("Google API error: status={}, body={}", clientResponse.statusCode(), body);
+						return Mono.error(new CustomException(ErrorCode.GOOGLE_TOKEN_REQUEST_FAILED));
+					})
+			)
 			.bodyToMono(GoogleTokenResponse.class)
 			.block();
+
+		if (response == null) {
+			throw new CustomException(ErrorCode.GOOGLE_TOKEN_REQUEST_FAILED);
+		}
 
 		return response.accessToken();
 	}

--- a/src/main/java/com/kt/mindLog/service/payment/PaymentService.java
+++ b/src/main/java/com/kt/mindLog/service/payment/PaymentService.java
@@ -15,6 +15,7 @@ import com.kt.mindLog.domain.payment.PaymentStatus;
 import com.kt.mindLog.domain.user.User;
 import com.kt.mindLog.dto.payment.request.PaymentConfirmRequest;
 import com.kt.mindLog.dto.payment.request.PaymentCreateRequest;
+import com.kt.mindLog.dto.payment.response.PaymentConfirmResponse;
 import com.kt.mindLog.dto.payment.response.PaymentCreateResponse;
 import com.kt.mindLog.dto.payment.response.PaymentListResponse;
 import com.kt.mindLog.dto.payment.response.TossPaymentResponse;
@@ -66,7 +67,7 @@ public class PaymentService {
 	}
 
 	@Transactional
-	public void confirm(PaymentConfirmRequest request) {
+	public PaymentConfirmResponse confirm(PaymentConfirmRequest request) {
 		Payment payment = paymentRepository.findByOrderId(request.orderId())
 			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_PAYMENT));
 
@@ -115,13 +116,15 @@ public class PaymentService {
 
 		// paymentKey 저장 및 결제 상태 완료로 변경
 		payment.updatePaymentKey(response.paymentKey());
-		payment.complete(response.approvedAt());
+		payment.complete(response.approvedAt().toLocalDateTime());
 
 		// 크레딧 충전
 		creditService.chargePaidCredit(
 			payment.getUser(),
 			payment
 		);
+
+		return PaymentConfirmResponse.from(response);
 	}
 
 	@Transactional


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #번호


## 🔨변경 사항(Changes)
-외부 API 호출 시 에러 처리 로직 추가 및 수정 (KAKAO, GOOGLE, TOSS)
-PaymentConfirmResponse DTO 추가
-TossPaymentResponse, PaymentConfirmResponse 의 approvedAt > 토스 상태값과 맞추기 위해 LocalDateTime 에서 OffsetDateTime 으로 변경 (도메인의 approvedAt 은 그대로 LocalDateTime 유지)

## 😉리뷰 요구사항



<br/>
