### PR TITLE
feat: implement summary card logic

### DIFF
--- a/src/main/java/com/kt/mindLog/controller/summary/SummaryController.java
+++ b/src/main/java/com/kt/mindLog/controller/summary/SummaryController.java
@@ -2,6 +2,8 @@ package com.kt.mindLog.controller.summary;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.kt.mindLog.dto.summary.request.SummaryCardUpdateRequest;
+import com.kt.mindLog.dto.summary.response.SummaryCardListResponse;
 import com.kt.mindLog.dto.summary.response.SummaryCardResponse;
 import com.kt.mindLog.dto.summary.response.SummaryCardUpdateResponse;
 import com.kt.mindLog.global.annotation.Login;
@@ -45,5 +48,10 @@ public class SummaryController {
 	public ApiResult<SummaryCardUpdateResponse> updateSummaryCard(@Login CustomUser user,
 		@PathVariable UUID summaryId, @RequestBody SummaryCardUpdateRequest request) {
 		return ApiResult.ok(summaryService.updateSummaryCard(user.getId(), summaryId, request));
+	}
+
+	@GetMapping
+	public ApiResult<Page<SummaryCardListResponse>> getSummaryCardList(@Login CustomUser user, Pageable pageable) {
+		return ApiResult.ok(summaryService.getSummaryCardList(user.getId(), pageable));
 	}
 }

--- a/src/main/java/com/kt/mindLog/controller/summary/SummaryController.java
+++ b/src/main/java/com/kt/mindLog/controller/summary/SummaryController.java
@@ -1,0 +1,49 @@
+package com.kt.mindLog.controller.summary;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.kt.mindLog.dto.summary.request.SummaryCardUpdateRequest;
+import com.kt.mindLog.dto.summary.response.SummaryCardResponse;
+import com.kt.mindLog.dto.summary.response.SummaryCardUpdateResponse;
+import com.kt.mindLog.global.annotation.Login;
+import com.kt.mindLog.global.common.response.ApiResult;
+import com.kt.mindLog.global.security.auth.CustomUser;
+import com.kt.mindLog.service.summary.SummaryService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/summaries")
+public class SummaryController {
+	private final SummaryService summaryService;
+
+	@PatchMapping("/{summaryId}/image")
+	public ApiResult<Void> uploadSummaryCard(@Login CustomUser user, @PathVariable UUID summaryId,
+		@RequestPart("summary_card") MultipartFile summaryCard) {
+		summaryService.uploadSummaryCard(user.getId(), summaryId, summaryCard);
+
+		return ApiResult.ok();
+	}
+
+	@GetMapping("/{summaryId}")
+	public ApiResult<SummaryCardResponse> getSummaryCard(@Login CustomUser user, @PathVariable UUID summaryId) {
+		return ApiResult.ok(summaryService.getSummaryCard(user.getId(), summaryId));
+	}
+
+	@PutMapping("/{summaryId}")
+	public ApiResult<SummaryCardUpdateResponse> updateSummaryCard(@Login CustomUser user,
+		@PathVariable UUID summaryId, @RequestBody SummaryCardUpdateRequest request) {
+		return ApiResult.ok(summaryService.updateSummaryCard(user.getId(), summaryId, request));
+	}
+}

--- a/src/main/java/com/kt/mindLog/domain/summary/EmotionCard.java
+++ b/src/main/java/com/kt/mindLog/domain/summary/EmotionCard.java
@@ -31,7 +31,10 @@ public class EmotionCard {
 	private UUID id;
 
 	@Column(columnDefinition = "TEXT")
-	private String imageUrl;
+	private String backImageUrl;
+
+	@Column(columnDefinition = "TEXT")
+	private String frontImageUrl;
 
 	private String interpretation;
 
@@ -48,10 +51,16 @@ public class EmotionCard {
 	private Session session;
 
 	@Builder
-	public EmotionCard(final String imageUrl, final User user, final Session session) {
-		this.imageUrl = imageUrl;
+	public EmotionCard(final String backImageUrl, final String frontImageUrl,
+		final User user, final Session session) {
+		this.backImageUrl = backImageUrl;
+		this.frontImageUrl = frontImageUrl;
 		this.user = user;
 		this.session = session;
 		this.createdAt = LocalDateTime.now();
+	}
+
+	public void updateFrontImageUrl(String frontImageUrl) {
+		this.frontImageUrl = frontImageUrl;
 	}
 }

--- a/src/main/java/com/kt/mindLog/domain/summary/SessionSummary.java
+++ b/src/main/java/com/kt/mindLog/domain/summary/SessionSummary.java
@@ -45,9 +45,6 @@ public class SessionSummary extends BaseEntity {
 	@Column(nullable = true)
 	private String visibility;
 
-	@Column(nullable = true)
-	private String cardImageUrl;
-
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "session_id", nullable = false)
 	private Session session;
@@ -67,10 +64,6 @@ public class SessionSummary extends BaseEntity {
 		this.updatedAt = LocalDateTime.now();
 		this.session = session;
 		this.user = user;
-	}
-
-	public void updateCardImageUrl(String cardImageUrl) {
-		this.cardImageUrl = cardImageUrl;
 	}
 
 	public void updateSummaryCard(String emotion, String fact, String insight) {

--- a/src/main/java/com/kt/mindLog/domain/summary/SessionSummary.java
+++ b/src/main/java/com/kt/mindLog/domain/summary/SessionSummary.java
@@ -45,6 +45,9 @@ public class SessionSummary extends BaseEntity {
 	@Column(nullable = true)
 	private String visibility;
 
+	@Column(nullable = true)
+	private String cardImageUrl;
+
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "session_id", nullable = false)
 	private Session session;
@@ -64,5 +67,16 @@ public class SessionSummary extends BaseEntity {
 		this.updatedAt = LocalDateTime.now();
 		this.session = session;
 		this.user = user;
+	}
+
+	public void updateCardImageUrl(String cardImageUrl) {
+		this.cardImageUrl = cardImageUrl;
+	}
+
+	public void updateSummaryCard(String emotion, String fact, String insight) {
+		if (emotion != null) this.emotion = emotion;
+		if (fact != null) this.fact = fact;
+	    if (insight != null) this.insight = insight;
+		this.isEdited = true;
 	}
 }

--- a/src/main/java/com/kt/mindLog/dto/summary/request/SummaryCardUpdateRequest.java
+++ b/src/main/java/com/kt/mindLog/dto/summary/request/SummaryCardUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.kt.mindLog.dto.summary.request;
+
+public record SummaryCardUpdateRequest(
+	String fact,
+	String emotion,
+	String insight
+) {
+}

--- a/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardListResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardListResponse.java
@@ -1,0 +1,42 @@
+package com.kt.mindLog.dto.summary.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.kt.mindLog.domain.summary.Emotion;
+import com.kt.mindLog.domain.summary.EmotionType;
+import com.kt.mindLog.domain.summary.SessionSummary;
+
+public record SummaryCardListResponse(
+	UUID summaryId,
+	UUID sessionId,
+	LocalDateTime createdAt,
+	String fact,
+	String emotion,
+	String insight,
+	List<EmotionInfo> emotions
+) {
+	public record EmotionInfo(
+		EmotionType emotionType,
+		Integer intensity
+	) {
+		public static EmotionInfo from(Emotion emotion) {
+			return new EmotionInfo(
+				emotion.getEmotionType(),
+				emotion.getIntensity()
+			);
+		}
+	}
+	public static SummaryCardListResponse of(SessionSummary summary, List<Emotion> emotions) {
+		return new SummaryCardListResponse(
+			summary.getId(),
+			summary.getSession().getId(),
+			summary.getCreatedAt(),
+			summary.getFact(),
+			summary.getEmotion(),
+			summary.getInsight(),
+			emotions.stream().map(EmotionInfo::from).toList()
+		);
+	}
+}

--- a/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardListResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardListResponse.java
@@ -1,42 +1,22 @@
 package com.kt.mindLog.dto.summary.response;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
-import com.kt.mindLog.domain.summary.Emotion;
-import com.kt.mindLog.domain.summary.EmotionType;
+import com.kt.mindLog.domain.summary.EmotionCard;
 import com.kt.mindLog.domain.summary.SessionSummary;
 
 public record SummaryCardListResponse(
 	UUID summaryId,
-	UUID sessionId,
-	LocalDateTime createdAt,
-	String fact,
-	String emotion,
-	String insight,
-	List<EmotionInfo> emotions
+	UUID cardId,
+	String frontImageUrl,
+	String backImageUrl
 ) {
-	public record EmotionInfo(
-		EmotionType emotionType,
-		Integer intensity
-	) {
-		public static EmotionInfo from(Emotion emotion) {
-			return new EmotionInfo(
-				emotion.getEmotionType(),
-				emotion.getIntensity()
-			);
-		}
-	}
-	public static SummaryCardListResponse of(SessionSummary summary, List<Emotion> emotions) {
+	public static SummaryCardListResponse of(SessionSummary summary, EmotionCard card) {
 		return new SummaryCardListResponse(
+			card.getId(),
 			summary.getId(),
-			summary.getSession().getId(),
-			summary.getCreatedAt(),
-			summary.getFact(),
-			summary.getEmotion(),
-			summary.getInsight(),
-			emotions.stream().map(EmotionInfo::from).toList()
+			card.getFrontImageUrl(),
+			card.getBackImageUrl()
 		);
 	}
 }

--- a/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardResponse.java
@@ -1,0 +1,34 @@
+package com.kt.mindLog.dto.summary.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.kt.mindLog.domain.summary.SessionSummary;
+
+public record SummaryCardResponse(
+	UUID summaryId,
+	UUID sessionId,
+	String fact,
+	String emotion,
+	String insight,
+	boolean isEdited,
+	String visibility,
+	String cardImageUrl,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+	public static SummaryCardResponse from(SessionSummary summary) {
+		return new SummaryCardResponse(
+			summary.getId(),
+			summary.getSession().getId(),
+			summary.getFact(),
+			summary.getEmotion(),
+			summary.getInsight(),
+			summary.isEdited(),
+			summary.getVisibility(),
+			summary.getCardImageUrl(),
+			summary.getCreatedAt(),
+			summary.getUpdatedAt()
+		);
+	}
+}

--- a/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardResponse.java
@@ -13,7 +13,6 @@ public record SummaryCardResponse(
 	String insight,
 	boolean isEdited,
 	String visibility,
-	String cardImageUrl,
 	LocalDateTime createdAt,
 	LocalDateTime updatedAt
 ) {
@@ -26,7 +25,6 @@ public record SummaryCardResponse(
 			summary.getInsight(),
 			summary.isEdited(),
 			summary.getVisibility(),
-			summary.getCardImageUrl(),
 			summary.getCreatedAt(),
 			summary.getUpdatedAt()
 		);

--- a/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardUpdateResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardUpdateResponse.java
@@ -1,0 +1,26 @@
+package com.kt.mindLog.dto.summary.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.kt.mindLog.domain.summary.SessionSummary;
+
+public record SummaryCardUpdateResponse(
+	UUID summaryId,
+	String fact,
+	String emotion,
+	String insight,
+	boolean isEdited,
+	LocalDateTime updatedAt
+) {
+	public static SummaryCardUpdateResponse from(SessionSummary summary) {
+		return new SummaryCardUpdateResponse(
+			summary.getId(),
+			summary.getFact(),
+			summary.getEmotion(),
+			summary.getInsight(),
+			summary.isEdited(),
+			summary.getUpdatedAt()
+		);
+	}
+}

--- a/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
@@ -75,6 +75,9 @@ public enum ErrorCode {
 	ENCRYPTION_FAILED(HttpStatus.BAD_REQUEST, "텍스트 암호화에 실패하였습니다"),
 	DECRYPTION_FAILED(HttpStatus.BAD_REQUEST, "텍스트 복호화에 실패하였습니다"),
 
+	// emotion
+	NOT_FOUND_CARD(HttpStatus.BAD_REQUEST, "감정 카드를 찾을 수 없습니다.")
+
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
 	// summary
 	INVALID_SESSION_SUMMARY(HttpStatus.BAD_REQUEST, "이미 분석 완료된 상담 세션입니다."),
 	NOT_FOUND_SUMMARY(HttpStatus.BAD_REQUEST, "해당 세션 요약 컨텍스트를 찾을 수 없습니다."),
+	NOT_SUMMARY_USER(HttpStatus.BAD_REQUEST, "본인 소유 세션만 사용 가능합니다."),
 
 	// credit
 	ALREADY_USED_CREDIT(HttpStatus.BAD_REQUEST, "이미 사용된 크레딧입니다."),

--- a/src/main/java/com/kt/mindLog/repository/summary/EmotionCardRepository.java
+++ b/src/main/java/com/kt/mindLog/repository/summary/EmotionCardRepository.java
@@ -1,5 +1,6 @@
 package com.kt.mindLog.repository.summary;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import com.kt.mindLog.domain.summary.EmotionCard;
 @Repository
 public interface EmotionCardRepository extends JpaRepository<EmotionCard, UUID> {
 	void deleteBySessionId(UUID sessionId);
+
+	Optional<EmotionCard> findBySessionId(UUID sessionId);
 }

--- a/src/main/java/com/kt/mindLog/repository/summary/EmotionRepository.java
+++ b/src/main/java/com/kt/mindLog/repository/summary/EmotionRepository.java
@@ -26,4 +26,6 @@ public interface EmotionRepository extends JpaRepository<Emotion, UUID> {
 	EmotionType findTopEmotionType(Session session);
 
 	void deleteBySessionId(UUID sessionId);
+
+	List<Emotion> findAllBySession(Session session);
 }

--- a/src/main/java/com/kt/mindLog/repository/summary/SummaryRepository.java
+++ b/src/main/java/com/kt/mindLog/repository/summary/SummaryRepository.java
@@ -2,6 +2,8 @@ package com.kt.mindLog.repository.summary;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,4 +18,6 @@ public interface SummaryRepository extends JpaRepository<SessionSummary, UUID> {
 	}
 
 	void deleteBySessionId(UUID sessionId);
+
+	Page<SessionSummary> findAllByUserId(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/kt/mindLog/repository/summary/SummaryRepository.java
+++ b/src/main/java/com/kt/mindLog/repository/summary/SummaryRepository.java
@@ -6,8 +6,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.kt.mindLog.domain.summary.SessionSummary;
+import com.kt.mindLog.global.common.exception.CustomException;
+import com.kt.mindLog.global.common.exception.ErrorCode;
 
 @Repository
 public interface SummaryRepository extends JpaRepository<SessionSummary, UUID> {
+	default SessionSummary findByIdOrThrow(UUID id, ErrorCode errorCode) {
+		return findById(id).orElseThrow(() -> new CustomException(errorCode));
+	}
+
 	void deleteBySessionId(UUID sessionId);
 }

--- a/src/main/java/com/kt/mindLog/service/s3/S3Path.java
+++ b/src/main/java/com/kt/mindLog/service/s3/S3Path.java
@@ -2,5 +2,6 @@ package com.kt.mindLog.service.s3;
 
 public enum S3Path {
 	PERSONA,
-	PROFILE
+	PROFILE,
+	SUMMARY
 }

--- a/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
+++ b/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
@@ -147,6 +147,7 @@ public class SummaryService {
 		return SummaryCardResponse.from(summary);
 	}
 
+	@Transactional
 	public SummaryCardUpdateResponse updateSummaryCard(final UUID userId, final UUID summaryId,
 		SummaryCardUpdateRequest request) {
 		SessionSummary summary = summaryRepository.findByIdOrThrow(summaryId, ErrorCode.NOT_FOUND_SUMMARY);

--- a/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
+++ b/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
@@ -165,9 +165,11 @@ public class SummaryService {
 
 	public Page<SummaryCardListResponse> getSummaryCardList(final UUID userId, Pageable pageable) {
 		return summaryRepository.findAllByUserId(userId, pageable)
-			.map(summary -> SummaryCardListResponse.of(
-				summary,
-				emotionRepository.findAllBySession(summary.getSession())
-			));
+			.map(summary -> {
+				EmotionCard card = emotionCardRepository.findBySessionId(summary.getId())
+					.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CARD));
+				return SummaryCardListResponse.of(summary, card);
+				}
+			);
 	}
 }

--- a/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
+++ b/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,17 +15,17 @@ import com.kt.mindLog.domain.session.Session;
 import com.kt.mindLog.domain.summary.EmotionCard;
 import com.kt.mindLog.domain.summary.SessionContextSummary;
 import com.kt.mindLog.domain.summary.SessionSummary;
-import com.kt.mindLog.domain.user.User;
 import com.kt.mindLog.dto.summary.request.SummaryCardUpdateRequest;
 import com.kt.mindLog.dto.summary.response.SessionEmotionResponse;
+import com.kt.mindLog.dto.summary.response.SummaryCardListResponse;
 import com.kt.mindLog.dto.summary.response.SummaryCardResponse;
 import com.kt.mindLog.dto.summary.response.SummaryCardUpdateResponse;
 import com.kt.mindLog.dto.summary.response.SummaryResponse;
+import com.kt.mindLog.global.common.exception.CustomException;
 import com.kt.mindLog.global.common.exception.ErrorCode;
 import com.kt.mindLog.global.common.support.Preconditions;
 import com.kt.mindLog.global.security.encryption.EncryptionConverter;
 import com.kt.mindLog.repository.SessionMessageRepository;
-import com.kt.mindLog.repository.UserRepository;
 import com.kt.mindLog.repository.session.SessionRepository;
 import com.kt.mindLog.repository.summary.EmotionCardRepository;
 import com.kt.mindLog.repository.summary.EmotionRepository;
@@ -45,7 +47,6 @@ public class SummaryService {
 	private final SummaryRepository summaryRepository;
 	private final SummaryContextRepository summaryContextRepository;
 	private final EmotionCardRepository emotionCardRepository;
-	private final UserRepository userRepository;
 
 	private final S3Service s3Service;
 
@@ -118,7 +119,7 @@ public class SummaryService {
 		var session = sessionRepository.findByIdOrThrow(sessionId, ErrorCode.NOT_FOUND_SESSION);
 
 		var card = EmotionCard.builder()
-			.imageUrl(url)
+			.backImageUrl(url)
 			.user(session.getUser())
 			.session(session)
 			.build();
@@ -132,11 +133,14 @@ public class SummaryService {
 
 		Preconditions.validate(summary.getUser().getId().equals(userId), ErrorCode.NOT_SUMMARY_USER);
 
-		String summaryCardUrl = s3Service.uploadImage(summaryCard, S3Path.SUMMARY);
+		Session session = summary.getSession();
 
-		summary.updateCardImageUrl(summaryCardUrl);
+		EmotionCard card = emotionCardRepository.findBySessionId(session.getId())
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CARD));
 
-		summaryRepository.save(summary);
+		String frontImageUrl = s3Service.uploadImage(summaryCard, S3Path.SUMMARY);
+
+		card.updateFrontImageUrl(frontImageUrl);
 	}
 
 	public SummaryCardResponse getSummaryCard(final UUID userId, final UUID summaryId) {
@@ -157,5 +161,13 @@ public class SummaryService {
 		summary.updateSummaryCard(request.emotion(), request.fact(), request.insight());
 
 		return SummaryCardUpdateResponse.from(summary);
+	}
+
+	public Page<SummaryCardListResponse> getSummaryCardList(final UUID userId, Pageable pageable) {
+		return summaryRepository.findAllByUserId(userId, pageable)
+			.map(summary -> SummaryCardListResponse.of(
+				summary,
+				emotionRepository.findAllBySession(summary.getSession())
+			));
 	}
 }

--- a/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
+++ b/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
@@ -7,20 +7,30 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.kt.mindLog.domain.session.Session;
 import com.kt.mindLog.domain.summary.EmotionCard;
 import com.kt.mindLog.domain.summary.SessionContextSummary;
+import com.kt.mindLog.domain.summary.SessionSummary;
+import com.kt.mindLog.domain.user.User;
+import com.kt.mindLog.dto.summary.request.SummaryCardUpdateRequest;
 import com.kt.mindLog.dto.summary.response.SessionEmotionResponse;
+import com.kt.mindLog.dto.summary.response.SummaryCardResponse;
+import com.kt.mindLog.dto.summary.response.SummaryCardUpdateResponse;
 import com.kt.mindLog.dto.summary.response.SummaryResponse;
 import com.kt.mindLog.global.common.exception.ErrorCode;
+import com.kt.mindLog.global.common.support.Preconditions;
 import com.kt.mindLog.global.security.encryption.EncryptionConverter;
 import com.kt.mindLog.repository.SessionMessageRepository;
+import com.kt.mindLog.repository.UserRepository;
 import com.kt.mindLog.repository.session.SessionRepository;
 import com.kt.mindLog.repository.summary.EmotionCardRepository;
 import com.kt.mindLog.repository.summary.EmotionRepository;
 import com.kt.mindLog.repository.summary.SummaryContextRepository;
 import com.kt.mindLog.repository.summary.SummaryRepository;
+import com.kt.mindLog.service.s3.S3Path;
+import com.kt.mindLog.service.s3.S3Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +45,9 @@ public class SummaryService {
 	private final SummaryRepository summaryRepository;
 	private final SummaryContextRepository summaryContextRepository;
 	private final EmotionCardRepository emotionCardRepository;
+	private final UserRepository userRepository;
+
+	private final S3Service s3Service;
 
 	private final ApplicationEventPublisher applicationEventPublisher;
 	private final EncryptionConverter encryptionConverter;
@@ -111,5 +124,37 @@ public class SummaryService {
 			.build();
 
 		emotionCardRepository.save(card);
+	}
+
+	@Transactional
+	public void uploadSummaryCard(final UUID userId, final UUID summaryId, final MultipartFile summaryCard) {
+		SessionSummary summary = summaryRepository.findByIdOrThrow(summaryId, ErrorCode.NOT_FOUND_SUMMARY);
+
+		Preconditions.validate(summary.getUser().getId().equals(userId), ErrorCode.NOT_SUMMARY_USER);
+
+		String summaryCardUrl = s3Service.uploadImage(summaryCard, S3Path.SUMMARY);
+
+		summary.updateCardImageUrl(summaryCardUrl);
+
+		summaryRepository.save(summary);
+	}
+
+	public SummaryCardResponse getSummaryCard(final UUID userId, final UUID summaryId) {
+		SessionSummary summary = summaryRepository.findByIdOrThrow(summaryId, ErrorCode.NOT_FOUND_SUMMARY);
+
+		Preconditions.validate(summary.getUser().getId().equals(userId), ErrorCode.NOT_SUMMARY_USER);
+
+		return SummaryCardResponse.from(summary);
+	}
+
+	public SummaryCardUpdateResponse updateSummaryCard(final UUID userId, final UUID summaryId,
+		SummaryCardUpdateRequest request) {
+		SessionSummary summary = summaryRepository.findByIdOrThrow(summaryId, ErrorCode.NOT_FOUND_SUMMARY);
+
+		Preconditions.validate(summary.getUser().getId().equals(userId), ErrorCode.NOT_SUMMARY_USER);
+
+		summary.updateSummaryCard(request.emotion(), request.fact(), request.insight());
+
+		return SummaryCardUpdateResponse.from(summary);
 	}
 }


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #27 


## 🔨변경 사항(Changes)
-마음 기록 생성 API (PATCH /v1/summaries/{summary_id}/image 로 API 변경)
-마음 기록 단건 조회 / 목록 조회 API
-마음 기록 텍스트 수정 API

## 😉리뷰 요구사항
마음 기록 조회 메서드에 텍스트 복호화 로직 추가 부탁드립니다

로직이 적절하게 잘 구현 되었는지 확인 부탁드립니다



<br/>
