### PR TITLE
refactor: add sessionId to SummaryCardListResponse

### DIFF
--- a/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardListResponse.java
+++ b/src/main/java/com/kt/mindLog/dto/summary/response/SummaryCardListResponse.java
@@ -9,14 +9,16 @@ import com.kt.mindLog.domain.summary.SessionSummary;
 public record SummaryCardListResponse(
 	UUID summaryId,
 	UUID cardId,
+	UUID sessionId,
 	String frontImageUrl,
 	String backImageUrl,
 	LocalDateTime createdAt
 ) {
 	public static SummaryCardListResponse of(SessionSummary summary, EmotionCard card) {
 		return new SummaryCardListResponse(
-			card.getId(),
 			summary.getId(),
+			card.getId(),
+			summary.getSession().getId(),
 			card.getFrontImageUrl(),
 			card.getBackImageUrl(),
 			summary.getCreatedAt()

--- a/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
+++ b/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
@@ -144,6 +144,7 @@ public class SummaryService {
 		card.updateFrontImageUrl(frontImageUrl);
 	}
 
+	@Transactional(readOnly = true)
 	public SummaryCardResponse getSummaryCard(final UUID userId, final UUID summaryId) {
 		SessionSummary summary = summaryRepository.findByIdOrThrow(summaryId, ErrorCode.NOT_FOUND_SUMMARY);
 
@@ -164,6 +165,7 @@ public class SummaryService {
 		return SummaryCardUpdateResponse.from(summary);
 	}
 
+	@Transactional(readOnly = true)
 	public Page<SummaryCardListResponse> getSummaryCardList(final UUID userId, Pageable pageable) {
 		return summaryRepository.findAllByUserId(userId, pageable)
 			.map(summary -> {


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #번호


## 🔨변경 사항(Changes)
-프론트 요청사항으로 카드 목록 조회 시 sessionId 추가
-SummaryCardListResponse 의 of() 에서 summaryId, cardId 순서가 바뀌어서 조회 안 되는 오류 해결

## 😉리뷰 요구사항



<br/>
