### PR TITLE
feat: delete redis data after session saved 

### DIFF
--- a/src/main/java/com/kt/mindLog/service/session/SessionMessageService.java
+++ b/src/main/java/com/kt/mindLog/service/session/SessionMessageService.java
@@ -103,7 +103,8 @@ public class SessionMessageService {
 	}
 
 	@Transactional
-	protected UUID saveSessionSummary(final UUID sessionId, final SessionSummaryResponse summary, final String imageUrl) {
+	protected UUID saveSessionSummary(final UUID sessionId, final SessionSummaryResponse summary,
+		final String imageUrl, final UUID userId) {
 		updateSessionStatus(sessionId, SessionStatus.COMPLETED);
 
 		var summaryId = summaryService.saveSummary(sessionId, summary.summary());
@@ -112,6 +113,10 @@ public class SessionMessageService {
 		summaryService.saveEmotions(sessionId, summary.emotions());
 
 		updateSessionStatus(sessionId, SessionStatus.SAVED);
+
+		redisService.deleteMessage(sessionId);
+		redisService.deleteHistory(userId);
+
 		return summaryId;
 	}
 

--- a/src/main/java/com/kt/mindLog/service/session/SessionStreamService.java
+++ b/src/main/java/com/kt/mindLog/service/session/SessionStreamService.java
@@ -154,11 +154,12 @@ public class SessionStreamService {
 		Preconditions.validate(session.getStatus().equals(SessionStatus.ACTIVE), ErrorCode.INVALID_SESSION);
 
 		return sseService.streamSSE(streamProperties.getFinalizeUri(), sessionId, null)
-			.handle((event, sink) -> handleFinalizeEvent(event, sink, sessionId))
+			.handle((event, sink) -> handleFinalizeEvent(event, sink, sessionId, userId))
 			.doOnError(e -> log.error("스트림 오류", e));
 	}
 
-	private void handleFinalizeEvent(final ServerSentEvent<String> event, final SynchronousSink<Object> sink, final UUID sessionId) {
+	private void handleFinalizeEvent(final ServerSentEvent<String> event, final SynchronousSink<Object> sink,
+		final UUID sessionId, final UUID userId) {
 		switch (event.event()) {
 			case "status" -> sink.next(event);
 
@@ -179,7 +180,7 @@ public class SessionStreamService {
 
 					String imageUrl = summary.card().get("image_url").asText();
 
-					var summaryId = messageService.saveSessionSummary(sessionId, summary, imageUrl);
+					var summaryId = messageService.saveSessionSummary(sessionId, summary, imageUrl, userId);
 
 					sink.next(ServerSentEvent.builder()
 						.event("ai_complete")


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #12


## 🔨변경 사항(Changes)
- 상담 종료 시, redis 에 적재된 상담 데이터(기존 상담 요약 데이터, 실시간 상담 데이터) 삭제


## 😉리뷰 요구사항



<br/>
