### PR TITLE
refactor: support uploading both front and back images for card

### DIFF
--- a/src/main/java/com/kt/mindLog/controller/summary/SummaryController.java
+++ b/src/main/java/com/kt/mindLog/controller/summary/SummaryController.java
@@ -33,8 +33,9 @@ public class SummaryController {
 
 	@PatchMapping("/{summaryId}/image")
 	public ApiResult<Void> uploadSummaryCard(@Login CustomUser user, @PathVariable UUID summaryId,
-		@RequestPart("summary_card") MultipartFile summaryCard) {
-		summaryService.uploadSummaryCard(user.getId(), summaryId, summaryCard);
+		@RequestPart("card_front_image") MultipartFile cardFrontImage,
+		@RequestPart("card_back_image") MultipartFile cardBackImage) {
+		summaryService.uploadSummaryCard(user.getId(), summaryId, cardFrontImage, cardBackImage);
 
 		return ApiResult.ok();
 	}

--- a/src/main/java/com/kt/mindLog/domain/summary/EmotionCard.java
+++ b/src/main/java/com/kt/mindLog/domain/summary/EmotionCard.java
@@ -60,7 +60,8 @@ public class EmotionCard {
 		this.createdAt = LocalDateTime.now();
 	}
 
-	public void updateFrontImageUrl(String frontImageUrl) {
+	public void updateImageUrl(String frontImageUrl, String backImageUrl) {
 		this.frontImageUrl = frontImageUrl;
+		this.backImageUrl = backImageUrl;
 	}
 }

--- a/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/mindLog/global/common/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
 	INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 확장자입니다."),
 	FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기는 5MB를 초과 할 수 없습니다."),
 	FILE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "파일 업로드에 실패했습니다."),
+	INVALID_IMAGE_FILE(HttpStatus.BAD_REQUEST, "이미지 파일이 존재하지 않거나 비어 있습니다"),
 
 	// summary
 	INVALID_SESSION_SUMMARY(HttpStatus.BAD_REQUEST, "이미 분석 완료된 상담 세션입니다."),

--- a/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
+++ b/src/main/java/com/kt/mindLog/service/summary/SummaryService.java
@@ -129,7 +129,13 @@ public class SummaryService {
 	}
 
 	@Transactional
-	public void uploadSummaryCard(final UUID userId, final UUID summaryId, final MultipartFile summaryCard) {
+	public void uploadSummaryCard(final UUID userId, final UUID summaryId, final MultipartFile cardFrontImage,
+		final MultipartFile cardBackImage) {
+		if (cardFrontImage == null || cardFrontImage.isEmpty() ||
+			cardBackImage == null || cardBackImage.isEmpty()) {
+			throw new CustomException(ErrorCode.INVALID_IMAGE_FILE);
+		}
+
 		SessionSummary summary = summaryRepository.findByIdOrThrow(summaryId, ErrorCode.NOT_FOUND_SUMMARY);
 
 		Preconditions.validate(summary.getUser().getId().equals(userId), ErrorCode.NOT_SUMMARY_USER);
@@ -140,10 +146,13 @@ public class SummaryService {
 			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CARD));
 		log.info("success to get card");
 
-		String frontImageUrl = s3Service.uploadImage(summaryCard, S3Path.SUMMARY);
-		log.info("success to upload image");
+		String frontImageUrl = s3Service.uploadImage(cardFrontImage, S3Path.SUMMARY);
+		log.info("success to upload front image. summaryId={}, url={}", summaryId, frontImageUrl);
 
-		card.updateFrontImageUrl(frontImageUrl);
+		String backImageUrl = s3Service.uploadImage(cardBackImage, S3Path.SUMMARY);
+		log.info("success to upload back image. summaryId={}, url={}", summaryId, backImageUrl);
+
+		card.updateImageUrl(frontImageUrl, backImageUrl);
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #번호


## 🔨변경 사항(Changes)
-마음 기록 카드 생성 시 카드 앞, 뒷면 모두 받아오도록 로직 수정


## 😉리뷰 요구사항



<br/>
